### PR TITLE
[Feature/#10] 채팅방 관련 API 구현 및 엔드포인트 수정

### DIFF
--- a/docs/api/v1/chat-rooms/DELETE_api_v1_chat-rooms_{roomId}.md
+++ b/docs/api/v1/chat-rooms/DELETE_api_v1_chat-rooms_{roomId}.md
@@ -1,13 +1,4 @@
-# 채팅방 삭제
-
-HTTP 요청 방식: DELETE
-개발 상태: 진행중
-도메인: CHAT-ROOMS
-엔드포인트: /api/v1/chat-rooms/{roomId}
-특이사항: 메시지, 일정 cascade
-마지막 수정시각: 2026년 4월 14일 오후 2:26
-
-## **[DELETE] /v1/chat-rooms/{roomId}**
+## **[DELETE] api/v1/chat-rooms/{roomId}**
 
 현재 로그인한 사용자가 소유한 특정 채팅방을 삭제합니다.
 
@@ -17,11 +8,11 @@ HTTP 요청 방식: DELETE
 
 ### **1. 기본 정보**
 
-| 항목 | 내용 |
-| --- | --- |
-| Method | `DELETE` |
-| URL | `/v1/chat-rooms/{roomId}` |
-| Summary | 채팅방 삭제 |
+| 항목 | 내용                          |
+| --- |-----------------------------|
+| Method | `DELETE`                    |
+| URL | `api/v1/chat-rooms/{roomId}`  |
+| Summary | 채팅방 삭제                      |
 | Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
 
 ---

--- a/docs/api/v1/chat-rooms/DELETE_v1_chat-rooms_{roomId}.md
+++ b/docs/api/v1/chat-rooms/DELETE_v1_chat-rooms_{roomId}.md
@@ -1,0 +1,151 @@
+# 채팅방 삭제
+
+HTTP 요청 방식: DELETE
+개발 상태: 진행중
+도메인: CHAT-ROOMS
+엔드포인트: /api/v1/chat-rooms/{roomId}
+특이사항: 메시지, 일정 cascade
+마지막 수정시각: 2026년 4월 14일 오후 2:26
+
+## **[DELETE] /v1/chat-rooms/{roomId}**
+
+현재 로그인한 사용자가 소유한 특정 채팅방을 삭제합니다.
+
+채팅방 삭제 시 연결된 메시지와 현재 일정도 함께 삭제됩니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `DELETE` |
+| URL | `/v1/chat-rooms/{roomId}` |
+| Summary | 채팅방 삭제 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Path Parameter**
+
+| Name | Required | Type | Description |
+| --- | --- | --- | --- |
+| roomId | Y | UUID | 삭제할 채팅방의 고유 ID |
+
+### **2.3 Body**
+
+- 없음
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (200 OK)**
+
+- **Description**: 채팅방이 성공적으로 삭제되었습니다.
+
+```json
+{
+  "roomId": "9d12a7e5-2a7b-4e86-bf5c-2d1b50dcb1a4",
+  "deleted": true
+}
+```
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or expired token."
+}
+```
+
+### **3.3 권한 없음 (403 Forbidden)**
+
+- **Description**: 해당 채팅방의 소유자가 아닌 경우입니다.
+
+```json
+{
+  "status": 403,
+  "error": "Forbidden",
+  "message": "You do not have permission to delete this chat room."
+}
+```
+
+### **3.4 리소스 없음 (404 Not Found)**
+
+- **Description**: 해당 `roomId`에 해당하는 채팅방이 존재하지 않는 경우입니다.
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "Chat room not found."
+}
+```
+
+### **3.5 서버 오류 (500 Internal Server Error)**
+
+- **Description**: 채팅방 삭제 중 서버 내부 오류가 발생한 경우입니다.
+
+```json
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "message": "Failed to delete chat room."
+}
+```
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **Resource Check**: `roomId`로 `chat_rooms` 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+4. **Authorization Check**: 조회한 채팅방의 `clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+5. **Delete**: `chat_rooms`에서 해당 채팅방을 삭제합니다.
+6. **Cascade Delete**: 외래키 제약에 의해 연결된 `chat_messages`, `itineraries`도 함께 삭제됩니다. `itineraries` 삭제 시 해당 일정을 참조하는 하위 데이터도 DB 정책에 따라 함께 정리됩니다.
+7. **Return**: 삭제 성공 여부를 응답으로 반환합니다.
+
+### **4.2 DB 삭제 구조 (`chat_rooms` Table)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID | 삭제 대상 채팅방 ID |
+| `clerk_id` | VARCHAR(255) | 채팅방 소유자 식별자 |
+| `created_at` | TIMESTAMP | 채팅방 생성 시각 |
+| `updated_at` | TIMESTAMP | 채팅방 마지막 수정 시각 |
+
+### **4.3 Cascade 영향 범위**
+
+| 대상 테이블 | 연결 컬럼 | 삭제 방식 |
+| --- | --- | --- |
+| `chat_messages` | `room_id` | `chat_rooms` 삭제 시 함께 삭제 |
+| `itineraries` | `room_id` | `chat_rooms` 삭제 시 함께 삭제 |
+| `itinerary_logs` | `itinerary_id` | 연결된 `itineraries` 삭제 시 함께 삭제 |
+
+> `reservations`는 `itinerary_id`를 통해 `itineraries`를 참조하지만, 현재 스키마상 `ON DELETE RESTRICT`이므로 실제 운영 시 채팅방 삭제 전에 예약 데이터 처리 정책을 팀 내에서 반드시 확정해야 합니다. 첨부 스키마에는 `reservations.itinerary_id REFERENCES itineraries(id) ON DELETE RESTRICT`로 적혀 있습니다.
+> 
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```bash
+curl -X DELETE https://your-api-domain.com/v1/chat-rooms/{roomId} \
+  -H "Authorization: Bearer <clerk_jwt_token>"
+```

--- a/docs/api/v1/chat-rooms/GET_api_v1_chat-rooms.md
+++ b/docs/api/v1/chat-rooms/GET_api_v1_chat-rooms.md
@@ -1,12 +1,4 @@
-# 내 채팅방 목록
-
-HTTP 요청 방식: GET
-개발 상태: 시작전
-도메인: CHAT-ROOMS
-엔드포인트: /v1/chat-rooms/
-마지막 수정시각: 2026년 4월 13일 오후 7:55
-
-## **[GET] /v1/chat-rooms**
+## **[GET] api/v1/chat-rooms**
 
 현재 로그인한 사용자의 채팅방 목록을 조회합니다.
 
@@ -14,11 +6,11 @@ HTTP 요청 방식: GET
 
 ### **1. 기본 정보**
 
-| 항목 | 내용 |
-| --- | --- |
-| Method | `GET` |
-| URL | `/v1/chat-rooms` |
-| Summary | 내 채팅방 목록 조회 |
+| 항목 | 내용                          |
+| --- |-----------------------------|
+| Method | `GET`                       |
+| URL | `api/v1/chat-rooms`         |
+| Summary | 내 채팅방 목록 조회                 |
 | Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
 
 ---

--- a/docs/api/v1/chat-rooms/GET_api_v1_chat-rooms_{roomId}.md
+++ b/docs/api/v1/chat-rooms/GET_api_v1_chat-rooms_{roomId}.md
@@ -1,14 +1,4 @@
-# 채팅방 상세
-
-HTTP 요청 방식: GET
-개발 상태: 진행중
-도메인: CHAT-ROOMS
-엔드포인트: /api/v1/chat-rooms/{roomId}
-특이사항: 채팅방 메타 정보 반환.
-itineraryId 필요
-마지막 수정시각: 2026년 4월 14일 오후 2:26
-
-## **[GET] /v1/chat-rooms/{roomId}**
+## **[GET] api/v1/chat-rooms/{roomId}**
 
 현재 로그인한 사용자가 소유한 특정 채팅방의 메타 정보를 조회합니다.
 
@@ -18,11 +8,11 @@ itineraryId 필요
 
 ### **1. 기본 정보**
 
-| 항목 | 내용 |
-| --- | --- |
-| Method | `GET` |
-| URL | `/v1/chat-rooms/{roomId}` |
-| Summary | 채팅방 상세 조회 |
+| 항목 | 내용                          |
+| --- |-----------------------------|
+| Method | `GET`                       |
+| URL | `api/v1/chat-rooms/{roomId}`  |
+| Summary | 채팅방 상세 조회                   |
 | Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
 
 ---

--- a/docs/api/v1/chat-rooms/GET_v1_chat-rooms.md
+++ b/docs/api/v1/chat-rooms/GET_v1_chat-rooms.md
@@ -1,0 +1,153 @@
+# 내 채팅방 목록
+
+HTTP 요청 방식: GET
+개발 상태: 시작전
+도메인: CHAT-ROOMS
+엔드포인트: /v1/chat-rooms/
+마지막 수정시각: 2026년 4월 13일 오후 7:55
+
+## **[GET] /v1/chat-rooms**
+
+현재 로그인한 사용자의 채팅방 목록을 조회합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `GET` |
+| URL | `/v1/chat-rooms` |
+| Summary | 내 채팅방 목록 조회 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Query Parameter**
+
+- 없음
+
+### **2.3 Body**
+
+- 없음
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (200 OK)**
+
+- **Description**: 현재 로그인한 사용자의 채팅방 목록을 성공적으로 조회했습니다.
+- **Body**:
+
+```json
+{
+  "rooms": [
+    {
+      "roomId": "9d12a7e5-2a7b-4e86-bf5c-2d1b50dcb1a4",
+      "aiSummary": "오사카 3박 4일 여행 계획 중",
+      "preferences": {
+        "budget": "economy",
+        "style": "food"
+      },
+      "createdAt": "2026-04-01T10:00:00",
+      "updatedAt": "2026-04-03T22:00:00"
+    },
+    {
+      "roomId": "15fdb4a4-7d9a-4b7c-9bcb-8d9a4f45be21",
+      "aiSummary": null,
+      "preferences": null,
+      "createdAt": "2026-04-02T14:30:00",
+      "updatedAt": "2026-04-02T14:30:00"
+    }
+  ]
+}
+```
+
+> 사용자의 채팅방이 하나도 없는 경우, `rooms`는 빈 배열 `[]` 로 반환합니다.
+> 
+
+예시:
+
+```json
+{
+  "rooms": []
+}
+```
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or expired token."
+}
+```
+
+### **3.3 사용자 없음 (404 Not Found)**
+
+- **Description**: JWT는 유효하지만 서비스 DB에 해당 사용자가 존재하지 않는 경우입니다.
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "User not found. Please sign up first."
+}
+```
+
+### **3.4 서버 오류 (500 Internal Server Error)**
+
+- **Description**: 채팅방 목록 조회 중 서버 내부 오류가 발생한 경우입니다.
+
+```json
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "message": "Failed to fetch chat rooms."
+}
+```
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **User Check**: `users` 테이블에서 해당 `clerk_id` 사용자가 존재하는지 확인합니다. 존재하지 않으면 404를 반환합니다.
+4. **Query**: `chat_rooms` 테이블에서 요청자의 `clerk_id`와 일치하는 채팅방 목록을 조회합니다.
+5. **Sort**: 채팅방 목록은 최근 수정 순(`updated_at DESC`)으로 정렬하여 반환합니다.
+6. **Return**: 조회된 채팅방 목록을 응답으로 반환합니다.
+
+### **4.2 DB 조회 구조 (`chat_rooms` Table)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID | 채팅방 고유 ID |
+| `clerk_id` | VARCHAR(255) | 채팅방 소유자 식별자 |
+| `ai_summary` | TEXT | AI가 요약한 대화 맥락 |
+| `preferences` | JSONB | 사용자 여행 선호도 |
+| `created_at` | TIMESTAMP | 생성 시각 |
+| `updated_at` | TIMESTAMP | 마지막 수정 시각 |
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```bash
+curl -X GET https://your-api-domain.com/v1/chat-rooms \
+  -H "Authorization: Bearer <clerk_jwt_token>"
+```

--- a/docs/api/v1/chat-rooms/GET_v1_chat-rooms_{roomId}.md
+++ b/docs/api/v1/chat-rooms/GET_v1_chat-rooms_{roomId}.md
@@ -1,0 +1,164 @@
+# 채팅방 상세
+
+HTTP 요청 방식: GET
+개발 상태: 진행중
+도메인: CHAT-ROOMS
+엔드포인트: /api/v1/chat-rooms/{roomId}
+특이사항: 채팅방 메타 정보 반환.
+itineraryId 필요
+마지막 수정시각: 2026년 4월 14일 오후 2:26
+
+## **[GET] /v1/chat-rooms/{roomId}**
+
+현재 로그인한 사용자가 소유한 특정 채팅방의 메타 정보를 조회합니다.
+
+필요 시 연결된 현재 여행 일정의 `itineraryId`도 함께 반환합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `GET` |
+| URL | `/v1/chat-rooms/{roomId}` |
+| Summary | 채팅방 상세 조회 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Path Parameter**
+
+| Name | Required | Type | Description |
+| --- | --- | --- | --- |
+| roomId | Y | UUID | 조회할 채팅방의 고유 ID |
+
+### **2.3 Body**
+
+- 없음
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (200 OK)**
+
+- **Description**: 채팅방 상세 정보를 성공적으로 조회했습니다.
+
+```json
+{
+  "roomId": "9d12a7e5-2a7b-4e86-bf5c-2d1b50dcb1a4",
+  "aiSummary": "오사카 3박 4일 여행 계획 중",
+  "preferences": {
+    "budget": "economy",
+    "style": "food"
+  },
+  "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+  "createdAt": "2026-04-01T10:00:00",
+  "updatedAt": "2026-04-03T22:00:00"
+}
+```
+
+- **연결된 현재 일정이 아직 없는 경우 예시**
+
+```json
+{
+  "roomId": "9d12a7e5-2a7b-4e86-bf5c-2d1b50dcb1a4",
+  "aiSummary": null,
+  "preferences": null,
+  "itineraryId": null,
+  "createdAt": "2026-04-01T10:00:00",
+  "updatedAt": "2026-04-01T10:00:00"
+}
+```
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or expired token."
+}
+```
+
+### **3.3 권한 없음 (403 Forbidden)**
+
+- **Description**: 해당 채팅방의 소유자가 아닌 경우입니다.
+
+```json
+{
+  "status": 403,
+  "error": "Forbidden",
+  "message": "You do not have permission to access this chat room."
+}
+```
+
+### **3.4 리소스 없음 (404 Not Found)**
+
+- **Description**: 해당 `roomId`에 해당하는 채팅방이 존재하지 않는 경우입니다.
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "Chat room not found."
+}
+```
+
+### **3.5 서버 오류 (500 Internal Server Error)**
+
+- **Description**: 채팅방 상세 조회 중 서버 내부 오류가 발생한 경우입니다.
+
+```json
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "message": "Failed to fetch chat room."
+}
+```
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **Resource Check**: `roomId`로 `chat_rooms` 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+4. **Authorization Check**: 조회한 채팅방의 `clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+5. **Join Itinerary**: `chat_rooms.id = itineraries.room_id` 조건으로 현재 연결된 일정이 있는지 조회합니다. 현재 구조상 `itineraries.room_id`는 UNIQUE이므로 최대 1건만 존재합니다.
+6. **Return**: 채팅방 메타 정보와 `itineraryId`를 함께 반환합니다. 일정이 없으면 `itineraryId`는 `null`입니다.
+
+### **4.2 DB 조회 구조 (`chat_rooms`, `itineraries`)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `chat_rooms.id` | UUID | 채팅방 고유 ID |
+| `chat_rooms.clerk_id` | VARCHAR(255) | 채팅방 소유자 식별자 |
+| `chat_rooms.ai_summary` | TEXT | AI가 요약한 대화 맥락 |
+| `chat_rooms.preferences` | JSONB | 사용자 여행 선호도 |
+| `chat_rooms.created_at` | TIMESTAMP | 채팅방 생성 시각 |
+| `chat_rooms.updated_at` | TIMESTAMP | 채팅방 마지막 수정 시각 |
+| `itineraries.id` | UUID | 연결된 현재 일정 ID |
+| `itineraries.room_id` | UUID | 채팅방과 1:1 연결된 FK |
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```bash
+curl -X GET https://your-api-domain.com/v1/chat-rooms/{roomId} \
+  -H "Authorization: Bearer <clerk_jwt_token>"
+```

--- a/docs/api/v1/chat-rooms/PATCH_api_v1_chat-rooms_{roomId}_name.md
+++ b/docs/api/v1/chat-rooms/PATCH_api_v1_chat-rooms_{roomId}_name.md
@@ -1,0 +1,154 @@
+## **[PATCH] api/v1/chat-rooms/{roomId}/name**
+
+현재 로그인한 사용자가 소유한 특정 채팅방의 이름을 수정합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `PATCH` |
+| URL | `api/v1/chat-rooms/{roomId}/name` |
+| Summary | 채팅방 이름 수정 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Path Parameter**
+
+| Name | Required | Type | Description |
+| --- | --- | --- | --- |
+| roomId | Y | UUID | 이름을 수정할 채팅방의 고유 ID |
+
+### **2.3 Body**
+
+```json
+{
+  "name": "오사카 3박 4일 여행"
+}
+```
+
+| Field | Required | Type | Description |
+| --- | --- | --- | --- |
+| `name` | Y | String | 변경할 채팅방 이름 |
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (200 OK)**
+
+- **Description**: 채팅방 이름이 성공적으로 수정되었습니다.
+
+```json
+{
+  "roomId": "9d12a7e5-2a7b-4e86-bf5c-2d1b50dcb1a4",
+  "name": "오사카 3박 4일 여행",
+  "updatedAt": "2026-04-03T22:00:00"
+}
+```
+
+### **3.2 잘못된 요청 (400 Bad Request)**
+
+- **Description**: 필수 필드가 누락되었거나 유효하지 않은 값이 입력된 경우입니다.
+
+```json
+{
+  "status": 400,
+  "error": "Bad Request",
+  "message": "name must not be blank."
+}
+```
+
+### **3.3 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or expired token."
+}
+```
+
+### **3.4 권한 없음 (403 Forbidden)**
+
+- **Description**: 해당 채팅방의 소유자가 아닌 경우입니다.
+
+```json
+{
+  "status": 403,
+  "error": "Forbidden",
+  "message": "You do not have permission to update this chat room."
+}
+```
+
+### **3.5 리소스 없음 (404 Not Found)**
+
+- **Description**: 해당 `roomId`에 해당하는 채팅방이 존재하지 않는 경우입니다.
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "Chat room not found."
+}
+```
+
+### **3.6 서버 오류 (500 Internal Server Error)**
+
+- **Description**: 채팅방 이름 수정 중 서버 내부 오류가 발생한 경우입니다.
+
+```json
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "message": "Failed to update chat room name."
+}
+```
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **Validation**: 요청 바디의 `name`이 비어있으면 400을 반환합니다.
+4. **Resource Check**: `roomId`로 `chat_rooms` 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+5. **Authorization Check**: 조회한 채팅방의 `clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+6. **Update**: `chat_rooms` 테이블의 `name` 컬럼을 업데이트하고 `updated_at`을 현재 시각으로 갱신합니다.
+7. **Return**: 수정된 `roomId`, `name`, `updatedAt`을 반환합니다.
+
+### **4.2 DB 수정 구조 (`chat_rooms` Table)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID | 채팅방 고유 ID |
+| `clerk_id` | VARCHAR(255) | 채팅방 소유자 식별자 |
+| `name` | VARCHAR(255) | 수정할 채팅방 이름 |
+| `updated_at` | TIMESTAMP | 마지막 수정 시각 (자동 갱신) |
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```bash
+curl -X PATCH https://your-api-domain.com/v1/chat-rooms/{roomId}/name \
+  -H "Authorization: Bearer <clerk_jwt_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "오사카 3박 4일 여행"
+  }'
+```

--- a/docs/api/v1/chat-rooms/POST_api_v1_chat-rooms.md
+++ b/docs/api/v1/chat-rooms/POST_api_v1_chat-rooms.md
@@ -1,0 +1,175 @@
+## **[POST] api/v1/chat-rooms**
+
+사용자의 새로운 여행 계획용 채팅방을 생성합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용                          |
+| --- |-----------------------------|
+| Method | `POST`                      |
+| URL | `api/v1/chat-rooms`           |
+| Summary | 채팅방 생성                      |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+#### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+#### 2.2 Body
+
+```json
+{
+  "destination": "제주도",
+  "startDate": "2026-05-01",
+  "endDate": "2026-05-03",
+  "budget": 300000,
+  "adultCount": 2,
+  "childCount": 1,
+  "childAges": [7],
+}
+```
+
+| Field | Required | Type | Description |
+| --- | --- | --- | --- |
+| `destination` | Y | String | 여행지 |
+| `startDate` | Y | Date | 여행 시작일 |
+| `endDate` | Y | Date | 여행 종료일 |
+| `budget` | N | Decimal | 예산 |
+| `adultCount` | Y | Int | 성인 수 (최소 1) |
+| `childCount` | N | Int | 아이 수 (기본값 0) |
+| `childAges` | N | Int[] | 아이 나이 배열 (`childCount > 0`이면 필수) |
+
+### **3. 응답 (Response)**
+
+#### **3.1 성공 (201 Created)**
+
+- **Description**: 채팅방이 성공적으로 생성되었습니다.
+
+```json
+{
+  "roomId": "9d12a7e5-2a7b-4e86-bf5c-2d1b50dcb1a4",
+  "itineraryId": "aaa-111",
+  "createdAt": "2026-04-03T22:00:00",
+  "updatedAt": "2026-04-03T22:00:00"
+}
+```
+
+#### **3.2 잘못된 요청 (400 Bad Request)**
+
+- **Description**: 필수 필드가 누락되었거나 유효하지 않은 값이 입력된 경우입니다.
+
+```json
+{
+  "status": 400,
+  "error": "Bad Request",
+  "message": "childAges must be provided when childCount > 0."
+}
+```
+
+#### **3.3 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or expired token."
+}
+```
+
+#### **3.4 리소스 없음 (404 Not Found)**
+
+- **Description**: 서비스 DB에 해당 사용자가 존재하지 않는 경우입니다. 먼저 회원가입 동기화 API를 호출해야 합니다.
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "User not found. Please sign up first."
+}
+```
+
+#### **3.5 서버 오류 (500 Internal Server Error)**
+
+- **Description**: 채팅방 생성 중 서버 내부 오류가 발생한 경우입니다.
+
+```json
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "message": "Failed to create chat room."
+}
+```
+
+---
+
+### 4. 비즈니스 로직 및 DB 스키마
+
+#### 4.1 동작 흐름 (Sequence)
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **User Check**: `users` 테이블에서 해당 `clerk_id` 사용자가 존재하는지 확인합니다. 존재하지 않으면 404를 반환합니다.
+4. **Validation**: `childCount > 0`인데 `childAges`가 누락되거나 길이가 맞지 않으면 400을 반환합니다.
+5. **Insert chat_rooms**: `chat_rooms` 테이블에 새 채팅방을 생성합니다.
+6. **Insert itineraries**: `itineraries` 테이블에 여행 일정을 초기화합니다. `day_plans`는 빈 객체 `{}`로 초기화합니다. → total_date, start_date, end_date, adults, chidlren, child_ages, destination, buget 값을 넣으면서 초기화
+7. **Return**: 생성된 `roomId`, `itineraryId` 및 시각 정보를 반환합니다.
+
+### 4.2 DB 저장 구조
+
+**`chat_rooms` Table**
+
+| Column | Value |
+| --- | --- |
+| `id` | `PK` |
+| `clerk_id` | JWT `sub` 클레임 |
+| `name` | 자동 생성: `"{N-1}박 {N}일 {destination} 여행"` |
+| `ai_summary` | `NULL` |
+| `preferences` | `NULL` |
+| `created_at` | 생성일자 |
+| `updated_at` | 업데이트일자 |
+
+**`itineraries` Table**
+
+| Column | Value |
+| --- | --- |
+| `id` | `PK` |
+| `room_id` | 생성된 `chat_rooms.id` |
+| `destination` | 요청 `destination` |
+| `start_date` | 요청 `startDate` |
+| `end_date` | 요청 `endDate` |
+| `total_days` | `endDate - startDate + 1` 계산 |
+| `budget` | 요청 `budget` |
+| `adult_count` | 요청 `adultCount` |
+| `child_count` | 요청 `childCount` |
+| `child_ages` | 요청 `childAges` |
+| `status` | `'draft'` |
+| `day_plans` | `'{}'` |
+| `created_at` | 생성일자 |
+| `updated_at` | 업데이트일자 |
+
+### 5. 호출 예시 (Example)
+
+```bash
+curl -X POST https://your-api-domain.com/v1/chat-rooms \
+  -H "Authorization: Bearer <clerk_jwt_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "destination": "제주도",
+    "startDate": "2026-05-01",
+    "endDate": "2026-05-03",
+    "budget": 300000,
+    "adultCount": 2,
+    "childCount": 1,
+    "childAges": [7],
+  }'
+```

--- a/docs/api/v1/users/POST_api_v1_users_signup.md
+++ b/docs/api/v1/users/POST_api_v1_users_signup.md
@@ -1,14 +1,14 @@
-## [POST] /api/users/signup
+## [POST] /api/v1/users/signup
 
 Clerk 인증 정보를 기반으로 서비스 데이터베이스에 사용자를 등록합니다. 멱등성(Idempotent)이 보장되어 여러 번 호출해도 안전합니다.
 
 ### 1. 기본 정보
 
-| **항목** | **내용** |
-| --- | --- |
-| **Method** | `POST` |
-| **URL** | `/api/users/signup` |
-| **Summary** | 회원가입 및 사용자 동기화 |
+| **항목** | **내용**                          |
+| --- |---------------------------------|
+| **Method** | `POST`                          |
+| **URL** | `/api/v1/users/signup`          |
+| **Summary** | 회원가입 및 사용자 동기화                  |
 | **Authentication** | **Bearer JWT** (Clerk 발급 토큰 필수) |
 
 ---

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.chatroom.controller;
 
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @Tag(name = "ChatRoom API", description = "채팅방 관련 API")
 @RestController
@@ -37,5 +40,15 @@ public class ChatRoomController {
     public Mono<GetChatRoomsResponse> getChatRooms(JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();
         return chatRoomService.getChatRooms(clerkId);
+    }
+
+    @Operation(summary = "채팅방 상세 조회", description = "현재 로그인한 사용자가 소유한 특정 채팅방의 메타 정보와 연결된 itineraryId를 반환합니다.")
+    @GetMapping("/{roomId}")
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<GetChatRoomResponse> getChatRoom(
+            @PathVariable UUID roomId,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return chatRoomService.getChatRoom(clerkId, roomId);
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.chatroom.controller;
 
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,7 +15,7 @@ import reactor.core.publisher.Mono;
 
 @Tag(name = "ChatRoom API", description = "채팅방 관련 API")
 @RestController
-@RequestMapping("/v1/chat-rooms")
+@RequestMapping("/api/v1/chat-rooms")
 @RequiredArgsConstructor
 public class ChatRoomController {
 
@@ -28,5 +29,13 @@ public class ChatRoomController {
             JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();
         return chatRoomService.createChatRoom(clerkId, request);
+    }
+
+    @Operation(summary = "내 채팅방 목록 조회", description = "현재 로그인한 사용자의 채팅방 목록을 최근 수정 순으로 반환합니다.")
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<GetChatRoomsResponse> getChatRooms(JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return chatRoomService.getChatRooms(clerkId);
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
@@ -5,6 +5,8 @@ import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
 import com.mju.capstone_backend.domain.chatroom.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,6 +53,17 @@ public class ChatRoomController {
             JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();
         return chatRoomService.getChatRoom(clerkId, roomId);
+    }
+
+    @Operation(summary = "채팅방 이름 수정", description = "현재 로그인한 사용자가 소유한 채팅방의 이름을 수정합니다.")
+    @PatchMapping("/{roomId}/name")
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<UpdateChatRoomNameResponse> updateChatRoomName(
+            @PathVariable UUID roomId,
+            @Valid @RequestBody UpdateChatRoomNameRequest request,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return chatRoomService.updateChatRoomName(clerkId, roomId, request.name());
     }
 
     @Operation(summary = "채팅방 삭제", description = "현재 로그인한 사용자가 소유한 채팅방을 삭제합니다. 연결된 메시지와 일정도 함께 삭제됩니다.")

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
@@ -1,0 +1,32 @@
+package com.mju.capstone_backend.domain.chatroom.controller;
+
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.service.ChatRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "ChatRoom API", description = "채팅방 관련 API")
+@RestController
+@RequestMapping("/v1/chat-rooms")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @Operation(summary = "채팅방 생성", description = "사용자의 새로운 여행 계획용 채팅방을 생성합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<CreateChatRoomResponse> createChatRoom(
+            @Valid @RequestBody CreateChatRoomRequest request,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return chatRoomService.createChatRoom(clerkId, request);
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomController.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.chatroom.controller;
 
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.service.ChatRoomService;
@@ -50,5 +51,15 @@ public class ChatRoomController {
             JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();
         return chatRoomService.getChatRoom(clerkId, roomId);
+    }
+
+    @Operation(summary = "채팅방 삭제", description = "현재 로그인한 사용자가 소유한 채팅방을 삭제합니다. 연결된 메시지와 일정도 함께 삭제됩니다.")
+    @DeleteMapping("/{roomId}")
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<DeleteChatRoomResponse> deleteChatRoom(
+            @PathVariable UUID roomId,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return chatRoomService.deleteChatRoom(clerkId, roomId);
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/CreateChatRoomRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/CreateChatRoomRequest.java
@@ -14,7 +14,7 @@ public record CreateChatRoomRequest(
         @NotNull LocalDate endDate,
         BigDecimal budget,
         @NotNull @Min(1) Integer adultCount,
-        Integer childCount,
+        @Min(0) Integer childCount,
         List<Integer> childAges
 ) {
     public int resolvedChildCount() {

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/CreateChatRoomRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/CreateChatRoomRequest.java
@@ -1,0 +1,23 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreateChatRoomRequest(
+        @NotBlank String destination,
+        @NotNull LocalDate startDate,
+        @NotNull LocalDate endDate,
+        BigDecimal budget,
+        @NotNull @Min(1) Integer adultCount,
+        Integer childCount,
+        List<Integer> childAges
+) {
+    public int resolvedChildCount() {
+        return childCount != null ? childCount : 0;
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/CreateChatRoomResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/CreateChatRoomResponse.java
@@ -1,0 +1,12 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CreateChatRoomResponse(
+        UUID roomId,
+        UUID itineraryId,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/DeleteChatRoomResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/DeleteChatRoomResponse.java
@@ -1,0 +1,9 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import java.util.UUID;
+
+public record DeleteChatRoomResponse(
+        UUID roomId,
+        boolean deleted
+) {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/GetChatRoomResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/GetChatRoomResponse.java
@@ -1,0 +1,15 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+public record GetChatRoomResponse(
+        UUID roomId,
+        String aiSummary,
+        Map<String, Object> preferences,
+        UUID itineraryId,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/GetChatRoomsResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/GetChatRoomsResponse.java
@@ -1,0 +1,18 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record GetChatRoomsResponse(
+        List<ChatRoomItem> rooms
+) {
+    public record ChatRoomItem(
+            UUID roomId,
+            String aiSummary,
+            Map<String, Object> preferences,
+            OffsetDateTime createdAt,
+            OffsetDateTime updatedAt
+    ) {}
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/UpdateChatRoomNameRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/UpdateChatRoomNameRequest.java
@@ -1,0 +1,8 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateChatRoomNameRequest(
+        @NotBlank String name
+) {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/UpdateChatRoomNameResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/dto/UpdateChatRoomNameResponse.java
@@ -1,0 +1,11 @@
+package com.mju.capstone_backend.domain.chatroom.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record UpdateChatRoomNameResponse(
+        UUID roomId,
+        String name,
+        OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/ChatRoom.java
@@ -1,0 +1,46 @@
+package com.mju.capstone_backend.domain.chatroom.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "chat_rooms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "clerk_id", nullable = false)
+    private String clerkId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "ai_summary")
+    private String aiSummary;
+
+    @Column(name = "preferences", columnDefinition = "jsonb")
+    private String preferences;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private OffsetDateTime updatedAt;
+
+    public static ChatRoom of(String clerkId, String name) {
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.clerkId = clerkId;
+        chatRoom.name = name;
+        return chatRoom;
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/ChatRoom.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -28,13 +31,15 @@ public class ChatRoom {
     @Column(name = "ai_summary")
     private String aiSummary;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "preferences", columnDefinition = "jsonb")
     private String preferences;
 
     @Column(name = "created_at", insertable = false, updatable = false)
     private OffsetDateTime createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private OffsetDateTime updatedAt;
 
     public static ChatRoom of(String clerkId, String name) {
@@ -42,5 +47,9 @@ public class ChatRoom {
         chatRoom.clerkId = clerkId;
         chatRoom.name = name;
         return chatRoom;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/Itinerary.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/Itinerary.java
@@ -1,0 +1,83 @@
+package com.mju.capstone_backend.domain.chatroom.entity;
+
+import com.mju.capstone_backend.global.converter.IntegerListConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "itineraries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Itinerary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "room_id", nullable = false)
+    private UUID roomId;
+
+    @Column(name = "destination", nullable = false)
+    private String destination;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "total_days", nullable = false)
+    private int totalDays;
+
+    @Column(name = "budget", precision = 12, scale = 2)
+    private BigDecimal budget;
+
+    @Column(name = "adult_count", nullable = false)
+    private int adultCount;
+
+    @Column(name = "child_count", nullable = false)
+    private int childCount;
+
+    @Convert(converter = IntegerListConverter.class)
+    @Column(name = "child_ages", columnDefinition = "jsonb")
+    private List<Integer> childAges;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "day_plans", columnDefinition = "jsonb", nullable = false)
+    private String dayPlans;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private OffsetDateTime updatedAt;
+
+    public static Itinerary of(UUID roomId, String destination, LocalDate startDate, LocalDate endDate,
+                               BigDecimal budget, int adultCount, int childCount, List<Integer> childAges) {
+        Itinerary itinerary = new Itinerary();
+        itinerary.roomId = roomId;
+        itinerary.destination = destination;
+        itinerary.startDate = startDate;
+        itinerary.endDate = endDate;
+        itinerary.totalDays = (int) ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        itinerary.budget = budget;
+        itinerary.adultCount = adultCount;
+        itinerary.childCount = childCount;
+        itinerary.childAges = childAges;
+        itinerary.status = "draft";
+        itinerary.dayPlans = "{}";
+        return itinerary;
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/Itinerary.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/entity/Itinerary.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -48,6 +50,7 @@ public class Itinerary {
     @Column(name = "child_count", nullable = false)
     private int childCount;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Convert(converter = IntegerListConverter.class)
     @Column(name = "child_ages", columnDefinition = "jsonb")
     private List<Integer> childAges;
@@ -55,6 +58,7 @@ public class Itinerary {
     @Column(name = "status", nullable = false, length = 20)
     private String status;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "day_plans", columnDefinition = "jsonb", nullable = false)
     private String dayPlans;
 

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ChatRoomRepository.java
@@ -3,7 +3,10 @@ package com.mju.capstone_backend.domain.chatroom.repository;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
+
+    List<ChatRoom> findByClerkIdOrderByUpdatedAtDesc(String clerkId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.mju.capstone_backend.domain.chatroom.repository;
+
+import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ItineraryRepository.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ItineraryRepository.java
@@ -1,0 +1,9 @@
+package com.mju.capstone_backend.domain.chatroom.repository;
+
+import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ItineraryRepository extends JpaRepository<Itinerary, UUID> {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ItineraryRepository.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/repository/ItineraryRepository.java
@@ -3,7 +3,10 @@ package com.mju.capstone_backend.domain.chatroom.repository;
 import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ItineraryRepository extends JpaRepository<Itinerary, UUID> {
+
+    Optional<Itinerary> findByRoomId(UUID roomId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
@@ -1,0 +1,10 @@
+package com.mju.capstone_backend.domain.chatroom.service;
+
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import reactor.core.publisher.Mono;
+
+public interface ChatRoomService {
+
+    Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request);
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.chatroom.service;
 
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import reactor.core.publisher.Mono;
@@ -15,4 +16,6 @@ public interface ChatRoomService {
     Mono<GetChatRoomsResponse> getChatRooms(String clerkId);
 
     Mono<GetChatRoomResponse> getChatRoom(String clerkId, UUID roomId);
+
+    Mono<DeleteChatRoomResponse> deleteChatRoom(String clerkId, UUID roomId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
@@ -2,9 +2,12 @@ package com.mju.capstone_backend.domain.chatroom.service;
 
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import reactor.core.publisher.Mono;
 
 public interface ChatRoomService {
 
     Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request);
+
+    Mono<GetChatRoomsResponse> getChatRooms(String clerkId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
@@ -5,6 +5,7 @@ import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -18,4 +19,6 @@ public interface ChatRoomService {
     Mono<GetChatRoomResponse> getChatRoom(String clerkId, UUID roomId);
 
     Mono<DeleteChatRoomResponse> deleteChatRoom(String clerkId, UUID roomId);
+
+    Mono<UpdateChatRoomNameResponse> updateChatRoomName(String clerkId, UUID roomId, String name);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomService.java
@@ -2,12 +2,17 @@ package com.mju.capstone_backend.domain.chatroom.service;
 
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 public interface ChatRoomService {
 
     Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request);
 
     Mono<GetChatRoomsResponse> getChatRooms(String clerkId);
+
+    Mono<GetChatRoomResponse> getChatRoom(String clerkId, UUID roomId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
@@ -21,6 +22,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -93,6 +95,32 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     .toList();
 
             return new GetChatRoomsResponse(items);
+        }).subscribeOn(dbScheduler);
+    }
+
+    @Override
+    public Mono<GetChatRoomResponse> getChatRoom(String clerkId, UUID roomId) {
+        return Mono.fromCallable(() -> {
+            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Chat room not found."));
+
+            if (!chatRoom.getClerkId().equals(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to access this chat room.");
+            }
+
+            UUID itineraryId = itineraryRepository.findByRoomId(roomId)
+                    .map(Itinerary::getId)
+                    .orElse(null);
+
+            return new GetChatRoomResponse(
+                    chatRoom.getId(),
+                    chatRoom.getAiSummary(),
+                    parsePreferences(chatRoom.getPreferences()),
+                    itineraryId,
+                    chatRoom.getCreatedAt(),
+                    chatRoom.getUpdatedAt()
+            );
         }).subscribeOn(dbScheduler);
     }
 

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
 import com.mju.capstone_backend.domain.chatroom.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
 import com.mju.capstone_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,6 +33,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ItineraryRepository itineraryRepository;
+    private final ReservationRepository reservationRepository;
     private final Scheduler dbScheduler;
     private final ObjectMapper objectMapper;
 
@@ -121,6 +124,30 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     chatRoom.getCreatedAt(),
                     chatRoom.getUpdatedAt()
             );
+        }).subscribeOn(dbScheduler);
+    }
+
+    @Override
+    public Mono<DeleteChatRoomResponse> deleteChatRoom(String clerkId, UUID roomId) {
+        return Mono.fromCallable(() -> {
+            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Chat room not found."));
+
+            if (!chatRoom.getClerkId().equals(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to delete this chat room.");
+            }
+
+            itineraryRepository.findByRoomId(roomId).ifPresent(itinerary -> {
+                if (reservationRepository.existsByItineraryId(itinerary.getId())) {
+                    throw new ResponseStatusException(HttpStatus.CONFLICT,
+                            "Cannot delete chat room with existing reservations.");
+                }
+            });
+
+            chatRoomRepository.deleteById(roomId);
+
+            return new DeleteChatRoomResponse(roomId, true);
         }).subscribeOn(dbScheduler);
     }
 

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -7,6 +7,7 @@ import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
@@ -75,7 +76,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     chatRoom.getCreatedAt(),
                     chatRoom.getUpdatedAt()
             );
-        }).subscribeOn(dbScheduler);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create chat room.")
+                );
     }
 
     @Override
@@ -98,7 +103,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     .toList();
 
             return new GetChatRoomsResponse(items);
-        }).subscribeOn(dbScheduler);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch chat rooms.")
+                );
     }
 
     @Override
@@ -124,7 +133,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     chatRoom.getCreatedAt(),
                     chatRoom.getUpdatedAt()
             );
-        }).subscribeOn(dbScheduler);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch chat room.")
+                );
     }
 
     @Override
@@ -148,7 +161,33 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             chatRoomRepository.deleteById(roomId);
 
             return new DeleteChatRoomResponse(roomId, true);
-        }).subscribeOn(dbScheduler);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete chat room.")
+                );
+    }
+
+    @Override
+    public Mono<UpdateChatRoomNameResponse> updateChatRoomName(String clerkId, UUID roomId, String name) {
+        return Mono.fromCallable(() -> {
+            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Chat room not found."));
+
+            if (!chatRoom.getClerkId().equals(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to update this chat room.");
+            }
+
+            chatRoom.updateName(name);
+            ChatRoom saved = chatRoomRepository.save(chatRoom);
+
+            return new UpdateChatRoomNameResponse(saved.getId(), saved.getName(), saved.getUpdatedAt());
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to update chat room name.")
+                );
     }
 
     private Map<String, Object> parsePreferences(String preferences) {

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -1,0 +1,70 @@
+package com.mju.capstone_backend.domain.chatroom.service;
+
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
+import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
+import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
+import com.mju.capstone_backend.domain.chatroom.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ItineraryRepository itineraryRepository;
+    private final Scheduler dbScheduler;
+
+    @Override
+    public Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request) {
+        return Mono.fromCallable(() -> {
+            if (!userRepository.existsById(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found. Please sign up first.");
+            }
+
+            int childCount = request.resolvedChildCount();
+            List<Integer> childAges = request.childAges();
+
+            if (childCount > 0 && (childAges == null || childAges.size() != childCount)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "childAges must be provided when childCount > 0.");
+            }
+
+            long totalDays = ChronoUnit.DAYS.between(request.startDate(), request.endDate()) + 1;
+            String name = (totalDays - 1) + "박 " + totalDays + "일 " + request.destination() + " 여행";
+            ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.of(clerkId, name));
+
+            Itinerary itinerary = itineraryRepository.save(
+                    Itinerary.of(
+                            chatRoom.getId(),
+                            request.destination(),
+                            request.startDate(),
+                            request.endDate(),
+                            request.budget(),
+                            request.adultCount(),
+                            childCount,
+                            childAges != null ? childAges : Collections.emptyList()
+                    )
+            );
+
+            return new CreateChatRoomResponse(
+                    chatRoom.getId(),
+                    itinerary.getId(),
+                    chatRoom.getCreatedAt(),
+                    chatRoom.getUpdatedAt()
+            );
+        }).subscribeOn(dbScheduler);
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -1,7 +1,10 @@
 package com.mju.capstone_backend.domain.chatroom.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
@@ -17,6 +20,7 @@ import reactor.core.scheduler.Scheduler;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ItineraryRepository itineraryRepository;
     private final Scheduler dbScheduler;
+    private final ObjectMapper objectMapper;
 
     @Override
     public Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request) {
@@ -66,5 +71,37 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     chatRoom.getUpdatedAt()
             );
         }).subscribeOn(dbScheduler);
+    }
+
+    @Override
+    public Mono<GetChatRoomsResponse> getChatRooms(String clerkId) {
+        return Mono.fromCallable(() -> {
+            if (!userRepository.existsById(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found. Please sign up first.");
+            }
+
+            List<GetChatRoomsResponse.ChatRoomItem> items = chatRoomRepository
+                    .findByClerkIdOrderByUpdatedAtDesc(clerkId)
+                    .stream()
+                    .map(room -> new GetChatRoomsResponse.ChatRoomItem(
+                            room.getId(),
+                            room.getAiSummary(),
+                            parsePreferences(room.getPreferences()),
+                            room.getCreatedAt(),
+                            room.getUpdatedAt()
+                    ))
+                    .toList();
+
+            return new GetChatRoomsResponse(items);
+        }).subscribeOn(dbScheduler);
+    }
+
+    private Map<String, Object> parsePreferences(String preferences) {
+        if (preferences == null) return null;
+        try {
+            return objectMapper.readValue(preferences, new TypeReference<>() {});
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
@@ -1,0 +1,61 @@
+package com.mju.capstone_backend.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "reservations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "itinerary_id", nullable = false)
+    private UUID itineraryId;
+
+    @Column(name = "type", nullable = false, length = 20)
+    private String type;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "booked_by", nullable = false, length = 10)
+    private String bookedBy;
+
+    @Column(name = "booking_url")
+    private String bookingUrl;
+
+    @Column(name = "external_ref_id")
+    private String externalRefId;
+
+    @Column(name = "detail", columnDefinition = "jsonb", nullable = false)
+    private String detail;
+
+    @Column(name = "total_price", precision = 12, scale = 2)
+    private BigDecimal totalPrice;
+
+    @Column(name = "currency", length = 3)
+    private String currency;
+
+    @Column(name = "reserved_at")
+    private OffsetDateTime reservedAt;
+
+    @Column(name = "cancelled_at")
+    private OffsetDateTime cancelledAt;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.mju.capstone_backend.domain.reservation.repository;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
+
+    boolean existsByItineraryId(UUID itineraryId);
+}

--- a/src/main/java/com/mju/capstone_backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/user/controller/UserController.java
@@ -14,7 +14,7 @@ import reactor.core.publisher.Mono;
 
 @Tag(name = "User API", description = "사용자 관련 API")
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/com/mju/capstone_backend/global/converter/IntegerListConverter.java
+++ b/src/main/java/com/mju/capstone_backend/global/converter/IntegerListConverter.java
@@ -1,0 +1,36 @@
+package com.mju.capstone_backend.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class IntegerListConverter implements AttributeConverter<List<Integer>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Integer> attribute) {
+        if (attribute == null) return "[]";
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            return "[]";
+        }
+    }
+
+    @Override
+    public List<Integer> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) return new ArrayList<>();
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mju/capstone_backend/global/exception/GlobalExceptionHandler.java
@@ -4,10 +4,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(WebExchangeBindException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + " " + error.getDefaultMessage() + ".")
+                .findFirst()
+                .orElse("Validation failed.");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, message));
+    }
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ErrorResponse> handleResponseStatus(ResponseStatusException ex) {

--- a/src/main/resources/db/migration/V3__create_chat_rooms_and_itineraries_table.sql
+++ b/src/main/resources/db/migration/V3__create_chat_rooms_and_itineraries_table.sql
@@ -1,0 +1,36 @@
+-- V3__create_chat_rooms_and_itineraries_table.sql
+-- 작성자: gkstmf
+-- 설명: chat_rooms, itineraries 테이블 생성
+
+CREATE TABLE chat_rooms
+(
+    id          UUID PRIMARY KEY         DEFAULT gen_random_uuid(),
+    clerk_id    VARCHAR(255) NOT NULL REFERENCES users (clerk_id),
+    name        VARCHAR(100) NOT NULL,
+    ai_summary  TEXT,
+    preferences JSONB,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_chat_rooms_clerk_id ON chat_rooms (clerk_id);
+
+CREATE TABLE itineraries
+(
+    id          UUID PRIMARY KEY         DEFAULT gen_random_uuid(),
+    room_id     UUID NOT NULL UNIQUE REFERENCES chat_rooms (id),
+    destination VARCHAR(255) NOT NULL,
+    budget      DECIMAL(12, 2),
+    adult_count INT  NOT NULL DEFAULT 1 CHECK (adult_count >= 1),
+    child_count INT  NOT NULL DEFAULT 0 CHECK (child_count >= 0),
+    child_ages  JSONB        DEFAULT '[]',
+    total_days  INT  NOT NULL CHECK (total_days >= 1),
+    start_date  DATE,
+    end_date    DATE,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'draft',
+    day_plans   JSONB        NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_itineraries_day_plans ON itineraries USING gin (day_plans);

--- a/src/main/resources/db/migration/V4__add_cascade_delete_to_chat_rooms.sql
+++ b/src/main/resources/db/migration/V4__add_cascade_delete_to_chat_rooms.sql
@@ -1,0 +1,10 @@
+-- V4__add_cascade_delete_to_chat_rooms.sql
+-- 작성자: gkstmf
+-- 설명: itineraries.room_id FK에 ON DELETE CASCADE 추가 (채팅방 삭제 시 일정 자동 삭제)
+
+ALTER TABLE itineraries
+    DROP CONSTRAINT itineraries_room_id_fkey;
+
+ALTER TABLE itineraries
+    ADD CONSTRAINT itineraries_room_id_fkey
+        FOREIGN KEY (room_id) REFERENCES chat_rooms (id) ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V5__create_reservations_table.sql
+++ b/src/main/resources/db/migration/V5__create_reservations_table.sql
@@ -1,0 +1,25 @@
+-- V5__create_reservations_table.sql
+-- 작성자: gkstmf
+-- 설명: reservations 테이블 생성
+
+CREATE TABLE reservations
+(
+    id              UUID PRIMARY KEY          DEFAULT gen_random_uuid(),
+    itinerary_id    UUID         NOT NULL REFERENCES itineraries (id) ON DELETE RESTRICT,
+    type            VARCHAR(20)  NOT NULL CHECK (type IN ('flight', 'accommodation', 'car_rental')),
+    status          VARCHAR(20)  NOT NULL DEFAULT 'confirmed' CHECK (status IN ('confirmed', 'changed', 'cancelled')),
+    booked_by       VARCHAR(10)  NOT NULL DEFAULT 'user' CHECK (booked_by IN ('user', 'ai')),
+    booking_url     TEXT,
+    external_ref_id VARCHAR(255),
+    detail          JSONB        NOT NULL DEFAULT '{}',
+    total_price     DECIMAL(12, 2),
+    currency        VARCHAR(3)            DEFAULT 'KRW',
+    reserved_at     TIMESTAMP WITH TIME ZONE,
+    cancelled_at    TIMESTAMP WITH TIME ZONE,
+    created_at      TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at      TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_reservations_itinerary_id ON reservations (itinerary_id);
+CREATE INDEX idx_reservations_status ON reservations (status);
+CREATE INDEX idx_reservations_detail ON reservations USING gin (detail);

--- a/src/test/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/chatroom/controller/ChatRoomControllerTest.java
@@ -1,0 +1,243 @@
+package com.mju.capstone_backend.domain.chatroom.controller;
+
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
+import com.mju.capstone_backend.domain.chatroom.service.ChatRoomService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+@TestPropertySource(locations = "file:.env")
+@DisplayName("ChatRoomController 슬라이스 테스트")
+class ChatRoomControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private ChatRoomService chatRoomService;
+
+    private static final String CLERK_ID = "user_testClerkId";
+    private static final UUID ROOM_ID = UUID.randomUUID();
+    private static final UUID ITINERARY_ID = UUID.randomUUID();
+
+    // ─── POST /api/v1/chat-rooms ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 생성 - 유효한 JWT와 요청 본문으로 201 반환")
+    void createChatRoom_withValidJwt_returns201() {
+        CreateChatRoomResponse response = new CreateChatRoomResponse(
+                ROOM_ID, ITINERARY_ID, OffsetDateTime.now(), OffsetDateTime.now()
+        );
+        when(chatRoomService.createChatRoom(eq(CLERK_ID), any(CreateChatRoomRequest.class)))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .post()
+                .uri("/api/v1/chat-rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""
+                        {
+                          "destination": "도쿄",
+                          "startDate": "2026-05-01",
+                          "endDate": "2026-05-03",
+                          "adultCount": 2
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody()
+                .jsonPath("$.roomId").isEqualTo(ROOM_ID.toString())
+                .jsonPath("$.itineraryId").isEqualTo(ITINERARY_ID.toString());
+
+        verify(chatRoomService).createChatRoom(eq(CLERK_ID), any(CreateChatRoomRequest.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - JWT 없이 요청 시 401 반환")
+    void createChatRoom_withoutJwt_returns401() {
+        webTestClient
+                .post()
+                .uri("/api/v1/chat-rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""
+                        {
+                          "destination": "도쿄",
+                          "startDate": "2026-05-01",
+                          "endDate": "2026-05-03",
+                          "adultCount": 2
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ─── GET /api/v1/chat-rooms ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 목록 조회 - 유효한 JWT로 200 반환")
+    void getChatRooms_withValidJwt_returns200() {
+        GetChatRoomsResponse response = new GetChatRoomsResponse(List.of());
+        when(chatRoomService.getChatRooms(CLERK_ID)).thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/chat-rooms")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.rooms").isArray();
+
+        verify(chatRoomService).getChatRooms(CLERK_ID);
+    }
+
+    @Test
+    @DisplayName("채팅방 목록 조회 - JWT 없이 요청 시 401 반환")
+    void getChatRooms_withoutJwt_returns401() {
+        webTestClient
+                .get()
+                .uri("/api/v1/chat-rooms")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ─── GET /api/v1/chat-rooms/{roomId} ─────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 상세 조회 - 유효한 JWT로 200 반환")
+    void getChatRoom_withValidJwt_returns200() {
+        GetChatRoomResponse response = new GetChatRoomResponse(
+                ROOM_ID, null, null, ITINERARY_ID, OffsetDateTime.now(), OffsetDateTime.now()
+        );
+        when(chatRoomService.getChatRoom(CLERK_ID, ROOM_ID)).thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/chat-rooms/{roomId}", ROOM_ID)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.roomId").isEqualTo(ROOM_ID.toString());
+
+        verify(chatRoomService).getChatRoom(CLERK_ID, ROOM_ID);
+    }
+
+    @Test
+    @DisplayName("채팅방 상세 조회 - JWT 없이 요청 시 401 반환")
+    void getChatRoom_withoutJwt_returns401() {
+        webTestClient
+                .get()
+                .uri("/api/v1/chat-rooms/{roomId}", ROOM_ID)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ─── PATCH /api/v1/chat-rooms/{roomId}/name ───────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 이름 수정 - 유효한 JWT와 요청 본문으로 200 반환")
+    void updateChatRoomName_withValidJwt_returns200() {
+        UpdateChatRoomNameResponse response = new UpdateChatRoomNameResponse(
+                ROOM_ID, "새로운 이름", OffsetDateTime.now()
+        );
+        when(chatRoomService.updateChatRoomName(CLERK_ID, ROOM_ID, "새로운 이름"))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .patch()
+                .uri("/api/v1/chat-rooms/{roomId}/name", ROOM_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""
+                        {"name": "새로운 이름"}
+                        """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.roomId").isEqualTo(ROOM_ID.toString())
+                .jsonPath("$.name").isEqualTo("새로운 이름");
+
+        verify(chatRoomService).updateChatRoomName(CLERK_ID, ROOM_ID, "새로운 이름");
+    }
+
+    @Test
+    @DisplayName("채팅방 이름 수정 - JWT 없이 요청 시 401 반환")
+    void updateChatRoomName_withoutJwt_returns401() {
+        webTestClient
+                .patch()
+                .uri("/api/v1/chat-rooms/{roomId}/name", ROOM_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""
+                        {"name": "새로운 이름"}
+                        """)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ─── DELETE /api/v1/chat-rooms/{roomId} ──────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 삭제 - 유효한 JWT로 200 반환")
+    void deleteChatRoom_withValidJwt_returns200() {
+        DeleteChatRoomResponse response = new DeleteChatRoomResponse(ROOM_ID, true);
+        when(chatRoomService.deleteChatRoom(CLERK_ID, ROOM_ID)).thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .delete()
+                .uri("/api/v1/chat-rooms/{roomId}", ROOM_ID)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.roomId").isEqualTo(ROOM_ID.toString())
+                .jsonPath("$.deleted").isEqualTo(true);
+
+        verify(chatRoomService).deleteChatRoom(CLERK_ID, ROOM_ID);
+    }
+
+    @Test
+    @DisplayName("채팅방 삭제 - JWT 없이 요청 시 401 반환")
+    void deleteChatRoom_withoutJwt_returns401() {
+        webTestClient
+                .delete()
+                .uri("/api/v1/chat-rooms/{roomId}", ROOM_ID)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+}

--- a/src/test/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImplTest.java
@@ -1,0 +1,347 @@
+package com.mju.capstone_backend.domain.chatroom.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
+import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
+import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
+import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
+import com.mju.capstone_backend.domain.chatroom.entity.Itinerary;
+import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
+import com.mju.capstone_backend.domain.chatroom.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
+import com.mju.capstone_backend.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpStatus.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatRoomServiceImpl 단위 테스트")
+class ChatRoomServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ItineraryRepository itineraryRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ChatRoomServiceImpl chatRoomService;
+
+    private static final String CLERK_ID = "user_testClerkId";
+    private static final UUID ROOM_ID = UUID.randomUUID();
+    private static final UUID ITINERARY_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void injectScheduler() throws Exception {
+        var field = ChatRoomServiceImpl.class.getDeclaredField("dbScheduler");
+        field.setAccessible(true);
+        field.set(chatRoomService, Schedulers.immediate());
+    }
+
+    // ─── createChatRoom ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 생성 - 정상 요청 시 ChatRoom과 Itinerary 저장 후 응답 반환")
+    void createChatRoom_success() {
+        CreateChatRoomRequest request = new CreateChatRoomRequest(
+                "도쿄", LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 3),
+                BigDecimal.valueOf(500000), 2, 0, null
+        );
+
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, CLERK_ID, "2박 3일 도쿄 여행");
+        Itinerary itinerary = mockItinerary(ITINERARY_ID, ROOM_ID);
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(chatRoom);
+        when(itineraryRepository.save(any(Itinerary.class))).thenReturn(itinerary);
+
+        StepVerifier.create(chatRoomService.createChatRoom(CLERK_ID, request))
+                .assertNext(res -> {
+                    assertThat(res.roomId()).isEqualTo(ROOM_ID);
+                    assertThat(res.itineraryId()).isEqualTo(ITINERARY_ID);
+                })
+                .verifyComplete();
+
+        verify(chatRoomRepository).save(any(ChatRoom.class));
+        verify(itineraryRepository).save(any(Itinerary.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - 존재하지 않는 사용자는 404 반환")
+    void createChatRoom_userNotFound_returns404() {
+        CreateChatRoomRequest request = new CreateChatRoomRequest(
+                "도쿄", LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 3),
+                null, 1, 0, null
+        );
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(false);
+
+        StepVerifier.create(chatRoomService.createChatRoom(CLERK_ID, request))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == NOT_FOUND)
+                .verify();
+
+        verify(chatRoomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - childCount > 0인데 childAges 누락 시 400 반환")
+    void createChatRoom_childAgesMissing_returns400() {
+        CreateChatRoomRequest request = new CreateChatRoomRequest(
+                "도쿄", LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 3),
+                null, 1, 2, null   // childCount=2 이지만 childAges=null
+        );
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+        StepVerifier.create(chatRoomService.createChatRoom(CLERK_ID, request))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == BAD_REQUEST)
+                .verify();
+    }
+
+    // ─── getChatRooms ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 목록 조회 - 정상 요청 시 목록 반환")
+    void getChatRooms_success() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, CLERK_ID, "테스트 채팅방");
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(chatRoomRepository.findByClerkIdOrderByUpdatedAtDesc(CLERK_ID))
+                .thenReturn(List.of(chatRoom));
+
+        StepVerifier.create(chatRoomService.getChatRooms(CLERK_ID))
+                .assertNext(res -> assertThat(res.rooms()).hasSize(1))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("채팅방 목록 조회 - 존재하지 않는 사용자는 404 반환")
+    void getChatRooms_userNotFound_returns404() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(false);
+
+        StepVerifier.create(chatRoomService.getChatRooms(CLERK_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == NOT_FOUND)
+                .verify();
+    }
+
+    // ─── getChatRoom ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 상세 조회 - 정상 요청 시 채팅방 정보 반환")
+    void getChatRoom_success() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, CLERK_ID, "테스트 채팅방");
+        Itinerary itinerary = mockItinerary(ITINERARY_ID, ROOM_ID);
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(itineraryRepository.findByRoomId(ROOM_ID)).thenReturn(Optional.of(itinerary));
+
+        StepVerifier.create(chatRoomService.getChatRoom(CLERK_ID, ROOM_ID))
+                .assertNext(res -> {
+                    assertThat(res.roomId()).isEqualTo(ROOM_ID);
+                    assertThat(res.itineraryId()).isEqualTo(ITINERARY_ID);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("채팅방 상세 조회 - 존재하지 않는 채팅방은 404 반환")
+    void getChatRoom_notFound_returns404() {
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(chatRoomService.getChatRoom(CLERK_ID, ROOM_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == NOT_FOUND)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("채팅방 상세 조회 - 다른 사용자의 채팅방 접근 시 403 반환")
+    void getChatRoom_otherUser_returns403() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, "user_otherClerkId", "타인의 채팅방");
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+        StepVerifier.create(chatRoomService.getChatRoom(CLERK_ID, ROOM_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == FORBIDDEN)
+                .verify();
+    }
+
+    // ─── updateChatRoomName ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 이름 수정 - 정상 요청 시 이름 수정 후 응답 반환")
+    void updateChatRoomName_success() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, CLERK_ID, "기존 이름");
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(chatRoomRepository.save(chatRoom)).thenReturn(chatRoom);
+
+        StepVerifier.create(chatRoomService.updateChatRoomName(CLERK_ID, ROOM_ID, "새 이름"))
+                .assertNext(res -> assertThat(res.roomId()).isEqualTo(ROOM_ID))
+                .verifyComplete();
+
+        verify(chatRoomRepository).save(chatRoom);
+    }
+
+    @Test
+    @DisplayName("채팅방 이름 수정 - 존재하지 않는 채팅방은 404 반환")
+    void updateChatRoomName_notFound_returns404() {
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(chatRoomService.updateChatRoomName(CLERK_ID, ROOM_ID, "새 이름"))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == NOT_FOUND)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("채팅방 이름 수정 - 다른 사용자의 채팅방 수정 시 403 반환")
+    void updateChatRoomName_otherUser_returns403() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, "user_otherClerkId", "타인의 채팅방");
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+        StepVerifier.create(chatRoomService.updateChatRoomName(CLERK_ID, ROOM_ID, "새 이름"))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == FORBIDDEN)
+                .verify();
+    }
+
+    // ─── deleteChatRoom ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채팅방 삭제 - 정상 요청 시 삭제 후 응답 반환")
+    void deleteChatRoom_success() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, CLERK_ID, "삭제할 채팅방");
+        Itinerary itinerary = mockItinerary(ITINERARY_ID, ROOM_ID);
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(itineraryRepository.findByRoomId(ROOM_ID)).thenReturn(Optional.of(itinerary));
+        when(reservationRepository.existsByItineraryId(ITINERARY_ID)).thenReturn(false);
+        doNothing().when(chatRoomRepository).deleteById(ROOM_ID);
+
+        StepVerifier.create(chatRoomService.deleteChatRoom(CLERK_ID, ROOM_ID))
+                .assertNext(res -> {
+                    assertThat(res.roomId()).isEqualTo(ROOM_ID);
+                    assertThat(res.deleted()).isTrue();
+                })
+                .verifyComplete();
+
+        verify(chatRoomRepository).deleteById(ROOM_ID);
+    }
+
+    @Test
+    @DisplayName("채팅방 삭제 - 존재하지 않는 채팅방은 404 반환")
+    void deleteChatRoom_notFound_returns404() {
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(chatRoomService.deleteChatRoom(CLERK_ID, ROOM_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == NOT_FOUND)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("채팅방 삭제 - 다른 사용자의 채팅방 삭제 시 403 반환")
+    void deleteChatRoom_otherUser_returns403() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, "user_otherClerkId", "타인의 채팅방");
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+        StepVerifier.create(chatRoomService.deleteChatRoom(CLERK_ID, ROOM_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == FORBIDDEN)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("채팅방 삭제 - 예약이 존재하는 채팅방 삭제 시 409 반환")
+    void deleteChatRoom_hasReservations_returns409() {
+        ChatRoom chatRoom = mockChatRoom(ROOM_ID, CLERK_ID, "예약 있는 채팅방");
+        Itinerary itinerary = mockItinerary(ITINERARY_ID, ROOM_ID);
+
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(itineraryRepository.findByRoomId(ROOM_ID)).thenReturn(Optional.of(itinerary));
+        when(reservationRepository.existsByItineraryId(ITINERARY_ID)).thenReturn(true);
+
+        StepVerifier.create(chatRoomService.deleteChatRoom(CLERK_ID, ROOM_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == CONFLICT)
+                .verify();
+
+        verify(chatRoomRepository, never()).deleteById(any());
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────────────
+
+    private ChatRoom mockChatRoom(UUID id, String clerkId, String name) {
+        ChatRoom chatRoom = ChatRoom.of(clerkId, name);
+        try {
+            var idField = ChatRoom.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(chatRoom, id);
+
+            var createdAtField = ChatRoom.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(chatRoom, OffsetDateTime.now());
+
+            var updatedAtField = ChatRoom.class.getDeclaredField("updatedAt");
+            updatedAtField.setAccessible(true);
+            updatedAtField.set(chatRoom, OffsetDateTime.now());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return chatRoom;
+    }
+
+    private Itinerary mockItinerary(UUID id, UUID roomId) {
+        Itinerary itinerary = Itinerary.of(
+                roomId, "도쿄",
+                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 3),
+                null, 1, 0, List.of()
+        );
+        try {
+            var idField = Itinerary.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(itinerary, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return itinerary;
+    }
+}

--- a/src/test/java/com/mju/capstone_backend/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/user/controller/UserControllerTest.java
@@ -41,7 +41,7 @@ class UserControllerTest {
                 .mutateWith(SecurityMockServerConfigurers.mockJwt()
                         .jwt(jwt -> jwt.subject(clerkId)))
                 .post()
-                .uri("/api/users/signup")
+                .uri("/api/v1/users/signup")
                 .exchange()
                 .expectStatus().isOk();
 
@@ -53,7 +53,7 @@ class UserControllerTest {
     void signup_withoutJwt_returns401() {
         webTestClient
                 .post()
-                .uri("/api/users/signup")
+                .uri("/api/v1/users/signup")
                 .exchange()
                 .expectStatus().isUnauthorized();
     }


### PR DESCRIPTION
# 요약
채팅방 관련 API 5개를 구현하고 엔드포인트를 수정합니다.

chat-rooms
- POST /api/v1/chat-rooms - 채팅방 생성
- GET /api/v1/chat-rooms - 채팅방 목록 조회
- GET /api/v1/chat-rooms/{roomId} - 채팅방 상세 조회
- DELETE /api/v1/chat-rooms/{roomId} - 채팅방 삭제
- PATCH /api/v1/chat-rooms/{roomId}/name - 채팅방 이름 수정

users
- POST /api/v1/users/signup - 엔드포인트 v1 추가

# 연관 이슈 및 Close 할 이슈 작성
close #10

# Pull Request 체크리스트
## TODO
- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현