### PR TITLE
[Feature/#16] 예약 관리 시스템(CRUD)

### DIFF
--- a/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
@@ -82,6 +82,36 @@
     }
     ```
     
+### **3.5 서버 내부 오류 (500 Internal Server Error)**
+
+- **Description**: 요청은 유효하지만, 서버 내 데이터 간의 참조 관계가 깨져 있거나 데이터가 유실된 경우입니다.
+    - 예약과 연결된 **일정(Itinerary)** 데이터가 없는 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Related itinerary data is missing."
+        }
+        ```
+    - 일정과 연결된 **채팅방(ChatRoom)** 데이터가 없는 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Related chat room data is missing."
+        }
+        ```
+    - 기타 예상치 못한 서버 내부 오류 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Failed to delete reservation."
+        }
+        ```
 
 ---
 
@@ -104,6 +134,6 @@
 ## **5. 호출 예시 (Example)**
 
 ```json
-curl -X DELETE https://your-api-domain.com/v1/reservations/{reservationId} \
+curl -X DELETE https://your-api-domain.com/api/v1/reservations/{reservationId} \
   -H "Authorization: Bearer <clerk_jwt_token>"
 ```

--- a/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
@@ -33,9 +33,16 @@
 
 ## **3. 응답 (Response)**
 
-### **3.1 성공 (204 No Content)**
+### **3.1 성공 (200 OK)**
 
-- **Description**: 예약이 성공적으로 삭제되었습니다. 응답 바디 없음.
+- **Description**: 예약이 성공적으로 삭제되었습니다.
+    
+    ```json
+    {
+      "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+      "deleted": true
+    }
+    ```
 
 ### **3.2 인증 실패 (401 Unauthorized)**
 

--- a/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
@@ -1,0 +1,102 @@
+## **[DELETE] /api/v1/reservations/{reservationId}**
+
+예약 레코드를 완전히 삭제합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `DELETE` |
+| URL | `/api/v1/reservations/{reservationId}` |
+| Summary | 예약 삭제 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Path Parameter**
+
+| Name | Required | Type | Description |
+| --- | --- | --- | --- |
+| reservationId | Y | UUID | 삭제할 예약의 고유 ID |
+
+---
+
+## **3. 응답 (Response)**
+
+### **3.1 성공 (204 No Content)**
+
+- **Description**: 예약이 성공적으로 삭제되었습니다. 응답 바디 없음.
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+    
+    ```json
+    {
+      "status": 401,
+      "error": "Unauthorized",
+      "message": "Invalid or expired token."
+    }
+    ```
+    
+
+### **3.3 권한 없음 (403 Forbidden)**
+
+- **Description**: 해당 예약의 소유자가 아닌 경우입니다.
+    
+    ```json
+    {
+      "status": 403,
+      "error": "Forbidden",
+      "message": "You do not have permission to delete this reservation."
+    }
+    ```
+    
+
+### **3.4 리소스 없음 (404 Not Found)**
+
+- **Description**: 해당 `reservationId`에 해당하는 예약이 존재하지 않는 경우입니다.
+    
+    ```json
+    {
+      "status": 404,
+      "error": "Not Found",
+      "message": "Reservation not found."
+    }
+    ```
+    
+
+---
+
+## **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **Resource Check**: `reservationId`로 reservations 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+4. **Authorization Check**: `itinerary_id → room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+5. **Delete**: `reservations` 테이블에서 해당 레코드를 삭제합니다.
+
+### **4.2 DB 삭제 구조**
+
+`reservations` 테이블에서 `id = reservationId` 조건으로 레코드를 삭제합니다.
+
+---
+
+## **5. 호출 예시 (Example)**
+
+```json
+curl -X DELETE https://your-api-domain.com/v1/reservations/{reservationId} \
+  -H "Authorization: Bearer <clerk_jwt_token>"
+```

--- a/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/DELETE_api_v1_reservations_{reservationId}.md
@@ -1,6 +1,6 @@
 ## **[DELETE] /api/v1/reservations/{reservationId}**
 
-예약 레코드를 완전히 삭제합니다.
+예약 레코드를 완전히 삭제합니다. (데이터 Hard Delete)
 
 ---
 

--- a/docs/api/v1/reservations/GET_api_v1_reservations.md
+++ b/docs/api/v1/reservations/GET_api_v1_reservations.md
@@ -1,0 +1,207 @@
+## **[GET] /api/v1/reservations**
+
+현재 로그인한 사용자의 예약 목록을 조회합니다.
+
+예약 유형(`type`)과 예약 상태(`status`)로 필터링할 수 있습니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `GET` |
+| URL | `/api/v1/reservations` |
+| Summary | 내 예약 목록 조회 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Query Parameter**
+
+| Name | Required | Type | Example | Description |
+| --- | --- | --- | --- | --- |
+| type | N | String | `flight` | 예약 유형 필터 |
+| status | N | String | `confirmed` | 예약 상태 필터 |
+- `type` 허용 값: `flight`, `accommodation`, `car_rental`
+- `status` 허용 값: `confirmed`, `changed`, `cancelled`
+
+### **2.3 Body**
+
+- 없음
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (200 OK)**
+
+- **Description**: 현재 로그인한 사용자의 예약 목록을 성공적으로 조회했습니다.
+
+```json
+{
+  "reservations": [
+    {
+      "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+      "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+      "type": "flight",
+      "status": "confirmed",
+      "bookedBy": "user",
+      "bookingUrl": "https://booking.example.com/flight/123",
+      "externalRefId": "KE12345678",
+      "detail": {
+        "airline": "Korean Air",
+        "flight_no": "KE721",
+        "departure": {
+          "airport": "ICN",
+          "datetime": "2026-05-01T09:00:00"
+        },
+        "arrival": {
+          "airport": "NRT",
+          "datetime": "2026-05-01T11:30:00"
+        }
+      },
+      "totalPrice": 320000.00,
+      "currency": "KRW",
+      "reservedAt": "2026-04-03T21:30:00",
+      "cancelledAt": null,
+      "createdAt": "2026-04-03T21:20:00",
+      "updatedAt": "2026-04-03T21:30:00"
+    },
+    {
+      "reservationId": "7f2f7e4f-5d29-47f7-8561-8ff22f0b2fd8",
+      "itineraryId": "3db203a5-d4fa-41b8-b30f-1d4cf58ce0e6",
+      "type": "flight",
+      "status": "confirmed",
+      "bookedBy": "ai",
+      "bookingUrl": "https://booking.example.com/flight/456",
+      "externalRefId": "OZ98765432",
+      "detail": {
+        "airline": "Asiana",
+        "flight_no": "OZ108",
+        "departure": {
+          "airport": "FCO",
+          "datetime": "2026-06-10T12:20:00"
+        },
+        "arrival": {
+          "airport": "ICN",
+          "datetime": "2026-06-11T06:20:00"
+        }
+      },
+      "totalPrice": 890000.00,
+      "currency": "KRW",
+      "reservedAt": "2026-04-05T10:10:00",
+      "cancelledAt": null,
+      "createdAt": "2026-04-05T10:00:00",
+      "updatedAt": "2026-04-05T10:10:00"
+    }
+  ]
+}
+```
+
+- **예약이 없는 경우 예시**
+
+```json
+{
+  "reservations": []
+}
+```
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or expired token."
+}
+```
+
+### **3.3 사용자 없음 (404 Not Found)**
+
+- **Description**: JWT는 유효하지만 서비스 DB에 해당 사용자가 존재하지 않는 경우입니다.
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "User not found. Please sign up first."
+}
+```
+
+### **3.4 잘못된 요청 (400 Bad Request)**
+
+- **Description**: `type` 또는 `status` 값이 허용된 값이 아닌 경우입니다.
+
+```json
+{
+  "status": 400,
+  "error": "Bad Request",
+  "message": "type must be one of: flight, accommodation, car_rental. status must be one of: confirmed, changed, cancelled."
+}
+```
+
+### **3.5 서버 오류 (500 Internal Server Error)**
+
+- **Description**: 예약 목록 조회 중 서버 내부 오류가 발생한 경우입니다.
+
+```json
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "message": "Failed to fetch reservations."
+}
+```
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **User Check**: `users` 테이블에서 해당 `clerk_id` 사용자가 존재하는지 확인합니다. 존재하지 않으면 404를 반환합니다.
+4. **Validation**: Query Parameter의 `type`, `status` 값이 허용된 값인지 검증합니다. 허용되지 않은 값이면 400을 반환합니다.
+5. **Join Query**: `users → chat_rooms → itineraries → reservations` 순으로 조인하여 현재 로그인한 사용자의 예약 목록만 조회합니다.
+6. **Filter**: `type`, `status`가 전달된 경우 해당 조건으로 추가 필터링합니다.
+7. **Sort**: 예약 목록은 최근 생성 순 또는 최근 수정 순(`updated_at DESC`)으로 정렬하여 반환합니다.
+8. **Return**: 예약 목록을 응답으로 반환합니다. 조건에 맞는 예약이 없으면 빈 배열 `[]`을 반환합니다.
+
+### **4.2 DB 조회 구조 (`reservations` Table)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID | 예약 고유 ID |
+| `itinerary_id` | UUID | 연결된 일정 ID |
+| `type` | VARCHAR(20) | 예약 유형 (`flight`, `accommodation`, `car_rental`) |
+| `status` | VARCHAR(20) | 예약 상태 (`confirmed`, `changed`, `cancelled`) |
+| `booked_by` | VARCHAR(10) | 예약 주체 (`user`, `ai`) |
+| `booking_url` | TEXT | 예약 링크 |
+| `external_ref_id` | VARCHAR(255) | 외부 예약 번호 |
+| `detail` | JSONB | 예약 상세 정보 |
+| `total_price` | DECIMAL(12,2) | 총 결제 금액 |
+| `currency` | VARCHAR(3) | 통화 코드 |
+| `reserved_at` | TIMESTAMP | 예약 완료 시각 |
+| `cancelled_at` | TIMESTAMP | 예약 취소 시각 |
+| `created_at` | TIMESTAMP | 생성 시각 |
+| `updated_at` | TIMESTAMP | 마지막 수정 시각 |
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```bash
+curl -X GET "https://your-api-domain.com/v1/reservations?type=flight&status=confirmed" \
+  -H "Authorization: Bearer <clerk_jwt_token>"
+```

--- a/docs/api/v1/reservations/GET_api_v1_reservations.md
+++ b/docs/api/v1/reservations/GET_api_v1_reservations.md
@@ -46,122 +46,130 @@
 
 - **Description**: 현재 로그인한 사용자의 예약 목록을 성공적으로 조회했습니다.
 
-```json
-{
-  "reservations": [
-    {
-      "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
-      "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
-      "type": "flight",
-      "status": "confirmed",
-      "bookedBy": "user",
-      "bookingUrl": "https://booking.example.com/flight/123",
-      "externalRefId": "KE12345678",
-      "detail": {
-        "airline": "Korean Air",
-        "flight_no": "KE721",
-        "departure": {
-          "airport": "ICN",
-          "datetime": "2026-05-01T09:00:00"
+  ```json
+  {
+    "reservations": [
+      {
+        "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+        "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+        "type": "flight",
+        "status": "confirmed",
+        "bookedBy": "user",
+        "bookingUrl": "https://booking.example.com/flight/123",
+        "externalRefId": "KE12345678",
+        "detail": {
+          "airline": "Korean Air",
+          "flight_no": "KE721",
+          "departure": {
+            "airport": "ICN",
+            "datetime": "2026-05-01T09:00:00"
+          },
+          "arrival": {
+            "airport": "NRT",
+            "datetime": "2026-05-01T11:30:00"
+          }
         },
-        "arrival": {
-          "airport": "NRT",
-          "datetime": "2026-05-01T11:30:00"
-        }
+        "totalPrice": 320000.00,
+        "currency": "KRW",
+        "reservedAt": "2026-04-03T21:30:00Z",
+        "cancelledAt": null,
+        "createdAt": "2026-04-03T21:20:00Z",
+        "updatedAt": "2026-04-03T21:30:00Z"
       },
-      "totalPrice": 320000.00,
-      "currency": "KRW",
-      "reservedAt": "2026-04-03T21:30:00",
-      "cancelledAt": null,
-      "createdAt": "2026-04-03T21:20:00",
-      "updatedAt": "2026-04-03T21:30:00"
-    },
-    {
-      "reservationId": "7f2f7e4f-5d29-47f7-8561-8ff22f0b2fd8",
-      "itineraryId": "3db203a5-d4fa-41b8-b30f-1d4cf58ce0e6",
-      "type": "flight",
-      "status": "confirmed",
-      "bookedBy": "ai",
-      "bookingUrl": "https://booking.example.com/flight/456",
-      "externalRefId": "OZ98765432",
-      "detail": {
-        "airline": "Asiana",
-        "flight_no": "OZ108",
-        "departure": {
-          "airport": "FCO",
-          "datetime": "2026-06-10T12:20:00"
+      {
+        "reservationId": "7f2f7e4f-5d29-47f7-8561-8ff22f0b2fd8",
+        "itineraryId": "3db203a5-d4fa-41b8-b30f-1d4cf58ce0e6",
+        "type": "flight",
+        "status": "confirmed",
+        "bookedBy": "ai",
+        "bookingUrl": "https://booking.example.com/flight/456",
+        "externalRefId": "OZ98765432",
+        "detail": {
+          "airline": "Asiana",
+          "flight_no": "OZ108",
+          "departure": {
+            "airport": "FCO",
+            "datetime": "2026-06-10T12:20:00"
+          },
+          "arrival": {
+            "airport": "ICN",
+            "datetime": "2026-06-11T06:20:00"
+          }
         },
-        "arrival": {
-          "airport": "ICN",
-          "datetime": "2026-06-11T06:20:00"
-        }
-      },
-      "totalPrice": 890000.00,
-      "currency": "KRW",
-      "reservedAt": "2026-04-05T10:10:00",
-      "cancelledAt": null,
-      "createdAt": "2026-04-05T10:00:00",
-      "updatedAt": "2026-04-05T10:10:00"
-    }
-  ]
-}
-```
+        "totalPrice": 890000.00,
+        "currency": "KRW",
+        "reservedAt": "2026-04-05T10:10:00Z",
+        "cancelledAt": null,
+        "createdAt": "2026-04-05T10:00:00Z",
+        "updatedAt": "2026-04-05T10:10:00Z"
+      }
+    ]
+  }
+  ```
 
 - **예약이 없는 경우 예시**
 
-```json
-{
-  "reservations": []
-}
-```
+  ```json
+  {
+    "reservations": []
+  }
+  ```
 
 ### **3.2 인증 실패 (401 Unauthorized)**
 
 - **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
 
-```json
-{
-  "status": 401,
-  "error": "Unauthorized",
-  "message": "Invalid or expired token."
-}
-```
+  ```json
+  {
+    "status": 401,
+    "error": "Unauthorized",
+    "message": "Invalid or expired token."
+  }
+  ```
 
 ### **3.3 사용자 없음 (404 Not Found)**
 
 - **Description**: JWT는 유효하지만 서비스 DB에 해당 사용자가 존재하지 않는 경우입니다.
 
-```json
-{
-  "status": 404,
-  "error": "Not Found",
-  "message": "User not found. Please sign up first."
-}
-```
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "message": "User not found. Please sign up first."
+  }
+  ```
 
 ### **3.4 잘못된 요청 (400 Bad Request)**
 
-- **Description**: `type` 또는 `status` 값이 허용된 값이 아닌 경우입니다.
+- **Description**: `type` 또는 `status` 값이 허용된 값이 아닌 경우입니다. 각 파라미터는 별도로 검증되어 독립적으로 오류를 반환합니다.
 
-```json
-{
-  "status": 400,
-  "error": "Bad Request",
-  "message": "type must be one of: flight, accommodation, car_rental. status must be one of: confirmed, changed, cancelled."
-}
-```
+  ```json
+  {
+    "status": 400,
+    "error": "Bad Request",
+    "message": "type must be one of: flight, accommodation, car_rental."
+  }
+  ```
+
+  ```json
+  {
+    "status": 400,
+    "error": "Bad Request",
+    "message": "status must be one of: confirmed, changed, cancelled."
+  }
+  ```
 
 ### **3.5 서버 오류 (500 Internal Server Error)**
 
 - **Description**: 예약 목록 조회 중 서버 내부 오류가 발생한 경우입니다.
 
-```json
-{
-  "status": 500,
-  "error": "Internal Server Error",
-  "message": "Failed to fetch reservations."
-}
-```
+  ```json
+  {
+    "status": 500,
+    "error": "Internal Server Error",
+    "message": "Failed to get reservations."
+  }
+  ```
 
 ---
 
@@ -202,6 +210,6 @@
 ### **5. 호출 예시 (Example)**
 
 ```bash
-curl -X GET "https://your-api-domain.com/v1/reservations?type=flight&status=confirmed" \
+curl -X GET "https://your-api-domain.com/api/v1/reservations?type=flight&status=confirmed" \
   -H "Authorization: Bearer <clerk_jwt_token>"
 ```

--- a/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
@@ -163,6 +163,23 @@
         }
         ```
         
+    - `detail` 제공 시 예약 `type`에 맞는 필수 키가 누락된 경우 (type별 필수 필드는 POST 명세의 **4.2** 참고):
+
+      | 케이스 | message |
+      | --- | --- |
+      | `detail` 필수 키 누락 | `detail.{field} is required for type '{type}'.` |
+      | `detail` 중첩 필수 키 누락 | `detail.{parent}.{field} is required for type '{type}'.` |
+      | `passengers` 빈 배열 또는 비리스트 | `detail.passengers must be a non-empty array for type 'flight'.` |
+      | `passengers[n]` name/passport 누락 | `detail.passengers[n] must include name and passport.` |
+
+        ```json
+        {
+          "status": 400,
+          "error": "Bad Request",
+          "message": "detail.departure.airport is required for type 'flight'."
+        }
+        ```
+        
 
 ### **3.5 리소스 없음 (404 Not Found)**
 
@@ -190,7 +207,8 @@
 5. **Validation**: `status` 값이 `cancelled` / `changed` 중 하나인지 확인합니다. 아니면 400을 반환합니다.
     - `status: cancelled` → `cancelledAt` 필수 확인. 누락 시 400 반환.
     - `status: changed` → `detail`, `totalPrice`, `reservedAt` 필수 확인. 누락 시 400 반환.
-6. **Update**: 요청에 포함된 필드만 업데이트하고 `updated_at`을 갱신합니다.
+6. **Detail Validation**: `detail`이 포함된 경우, 기존 예약의 `type`에 따라 필수 키를 검증합니다. 누락된 키가 있으면 400을 반환합니다.
+7. **Update**: 요청에 포함된 필드만 업데이트하고 `updated_at`을 갱신합니다.
 
 ### **4.2 DB 업데이트 구조 (reservations Table)**
 

--- a/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
@@ -31,27 +31,48 @@
 
 ### **2.3 Body**
 
-최소 하나의 필드는 포함되어야 합니다.
+`status` 값에 따라 필요한 필드가 달라집니다.
+
+**Case 1. `status: "cancelled"` — 예약 취소**
 
 ```json
 {
   "status": "cancelled",
-  "detail": {...},
-  "totalPrice": 290000.00,
-  "currency": "KRW",
-  "reservedAt": "2026-04-03T21:30:00",
   "cancelledAt": "2026-04-10T10:00:00"
 }
 ```
 
 | Field | Required | Type | Description |
 | --- | --- | --- | --- |
-| `status` | N | String | `confirmed` | `changed` | `cancelled` |
-| `detail` | N | JSONB | 수정할 예약 상세 정보 |
-| `totalPrice` | N | Decimal | 수정할 총 결제 금액 |
-| `currency` | N | String | 수정할 통화 코드 |
-| `reservedAt` | N | TIMESTAMP | 수정할 예약 완료 일시 |
-| `cancelledAt` | N | TIMESTAMP | 취소 일시 (`status: cancelled` 시 함께 전달) |
+| `status` | Y | String | `cancelled` 고정 |
+| `cancelledAt` | Y | TIMESTAMP | 취소 일시 |
+
+**Case 2. `status: "changed"` — 예약 변경**
+
+```json
+{
+  "status": "changed",
+  "detail": {
+    "airline": "아시아나",
+    "flight_no": "OZ108",
+    "departure": {"airport": "ICN", "datetime": "2026-05-02T09:00:00"},
+    "arrival": {"airport": "NRT", "datetime": "2026-05-02T11:30:00"},
+    "seat_class": "economy",
+    "passengers": [{"name": "홍길동", "passport": "M12345678"}]
+  },
+  "totalPrice": 290000.00,
+  "currency": "KRW",
+  "reservedAt": "2026-04-10T10:00:00"
+}
+```
+
+| Field | Required | Type | Description |
+| --- | --- | --- | --- |
+| `status` | Y | String | `changed` 고정 |
+| `detail` | Y | JSONB | 변경된 예약 상세 정보 |
+| `totalPrice` | Y | Decimal | 변경된 총 결제 금액 |
+| `currency` | N | String | 통화 코드 (기본값 `KRW`) |
+| `reservedAt` | Y | TIMESTAMP | 변경된 예약 완료 일시 |
 
 ---
 
@@ -60,15 +81,28 @@
 ### **3.1 성공 (200 OK)**
 
 - **Description**: 예약이 성공적으로 수정되었습니다.
-    
-    ```json
-    {
-      "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
-      "status": "cancelled",
-      "updatedAt": "2026-04-10T10:00:00"
-    }
-    ```
-    
+    - **Case 1. `status: "cancelled"`**
+        
+        ```json
+        {
+          "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+          "status": "cancelled",
+          "cancelledAt": "2026-04-10T10:00:00",
+          "updatedAt": "2026-04-10T10:00:00"
+        }
+        ```
+        
+    - **Case 2. `status: "changed"`**
+        
+        ```json
+        {
+          "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+          "status": "changed",
+          "reservedAt": "2026-04-10T10:00:00",
+          "updatedAt": "2026-04-10T10:00:00"
+        }
+        ```
+        
 
 ### **3.2 인증 실패 (401 Unauthorized)**
 
@@ -98,16 +132,37 @@
 
 ### **3.4 잘못된 요청 (400 Bad Request)**
 
-- **Description**: 최소 하나의 필드가 포함되어 있지 않거나 허용되지 않은 값인 경우입니다.
-    
-    ```json
-    {
-      "status": 400,
-      "error": "Bad Request",
-      "message": "At least one field must be provided."
-    }
-    ```
-    
+- **Description**: 필수 필드가 누락되었거나 허용되지 않은 값인 경우입니다.
+    - `status` 값이 허용되지 않은 경우:
+        
+        ```json
+        {
+          "status": 400,
+          "error": "Bad Request",
+          "message": "status must be one of: cancelled, changed."
+        }
+        ```
+        
+    - `status: cancelled`인데 `cancelledAt` 누락된 경우:
+        
+        ```json
+        {
+          "status": 400,
+          "error": "Bad Request",
+          "message": "cancelledAt is required when status is cancelled."
+        }
+        ```
+        
+    - `status: changed`인데 필수 필드 누락된 경우:
+        
+        ```json
+        {
+          "status": 400,
+          "error": "Bad Request",
+          "message": "detail, totalPrice, reservedAt are required when status is changed."
+        }
+        ```
+        
 
 ### **3.5 리소스 없음 (404 Not Found)**
 
@@ -132,19 +187,30 @@
 2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
 3. **Resource Check**: `reservationId`로 reservations 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
 4. **Authorization Check**: `itinerary_id → room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
-5. **Validation**: 요청 body에 최소 하나의 필드가 포함되어 있는지 확인합니다. `status` 값이 허용된 값인지 검증합니다. 없으면 400을 반환합니다.
+5. **Validation**: `status` 값이 `cancelled` / `changed` 중 하나인지 확인합니다. 아니면 400을 반환합니다.
+    - `status: cancelled` → `cancelledAt` 필수 확인. 누락 시 400 반환.
+    - `status: changed` → `detail`, `totalPrice`, `reservedAt` 필수 확인. 누락 시 400 반환.
 6. **Update**: 요청에 포함된 필드만 업데이트하고 `updated_at`을 갱신합니다.
 
 ### **4.2 DB 업데이트 구조 (reservations Table)**
 
+***Case 1. `cancelled`***
+
 | Column | Type | Description |
 | --- | --- | --- |
-| `status` | VARCHAR(20) | 요청에 포함된 경우 업데이트 |
-| `detail` | JSONB | 요청에 포함된 경우 업데이트 |
-| `total_price` | DECIMAL(12,2) | 요청에 포함된 경우 업데이트 |
+| `status` | VARCHAR(20) | `cancelled`로 업데이트 |
+| `cancelled_at` | TIMESTAMP | 취소 일시로 업데이트 |
+| `updated_at` | TIMESTAMP | 현재 시각으로 업데이트 |
+
+***Case 2. `changed`***
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `status` | VARCHAR(20) | `changed`로 업데이트 |
+| `detail` | JSONB | 변경된 상세 정보로 업데이트 |
+| `total_price` | DECIMAL(12,2) | 변경된 금액으로 업데이트 |
 | `currency` | VARCHAR(3) | 요청에 포함된 경우 업데이트 |
-| `reserved_at` | TIMESTAMP | 요청에 포함된 경우 업데이트 |
-| `cancelled_at` | TIMESTAMP | 요청에 포함된 경우 업데이트 |
+| `reserved_at` | TIMESTAMP | 변경된 예약 일시로 업데이트 |
 | `updated_at` | TIMESTAMP | 현재 시각으로 업데이트 |
 
 ---
@@ -152,8 +218,15 @@
 ### **5. 호출 예시 (Example)**
 
 ```json
+# 취소
 curl -X PATCH https://your-api-domain.com/v1/reservations/{reservationId} \
   -H "Authorization: Bearer <clerk_jwt_token>" \
   -H "Content-Type: application/json" \
   -d '{"status": "cancelled", "cancelledAt": "2026-04-10T10:00:00"}'
+
+# 변경
+curl -X PATCH https://your-api-domain.com/v1/reservations/{reservationId} \
+  -H "Authorization: Bearer <clerk_jwt_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "changed", "detail": {...}, "totalPrice": 290000.00, "reservedAt": "2026-04-10T10:00:00"}'
 ```

--- a/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
@@ -1,0 +1,159 @@
+## **[PATCH] /api/v1/reservations/{reservationId}**
+
+예약 상태 변경, detail 수정, 가격 등을 업데이트합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `PATCH` |
+| URL | `/api/v1/reservations/{reservationId}` |
+| Summary | 예약 수정 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Path Parameter**
+
+| Name | Required | Type | Description |
+| --- | --- | --- | --- |
+| reservationId | Y | UUID | 수정할 예약의 고유 ID |
+
+### **2.3 Body**
+
+최소 하나의 필드는 포함되어야 합니다.
+
+```json
+{
+  "status": "cancelled",
+  "detail": {...},
+  "totalPrice": 290000.00,
+  "currency": "KRW",
+  "reservedAt": "2026-04-03T21:30:00",
+  "cancelledAt": "2026-04-10T10:00:00"
+}
+```
+
+| Field | Required | Type | Description |
+| --- | --- | --- | --- |
+| `status` | N | String | `confirmed` | `changed` | `cancelled` |
+| `detail` | N | JSONB | 수정할 예약 상세 정보 |
+| `totalPrice` | N | Decimal | 수정할 총 결제 금액 |
+| `currency` | N | String | 수정할 통화 코드 |
+| `reservedAt` | N | TIMESTAMP | 수정할 예약 완료 일시 |
+| `cancelledAt` | N | TIMESTAMP | 취소 일시 (`status: cancelled` 시 함께 전달) |
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (200 OK)**
+
+- **Description**: 예약이 성공적으로 수정되었습니다.
+    
+    ```json
+    {
+      "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+      "status": "cancelled",
+      "updatedAt": "2026-04-10T10:00:00"
+    }
+    ```
+    
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+    
+    ```json
+    {
+      "status": 401,
+      "error": "Unauthorized",
+      "message": "Invalid or expired token."
+    }
+    ```
+    
+
+### **3.3 권한 없음 (403 Forbidden)**
+
+- **Description**: 해당 예약의 소유자가 아닌 경우입니다.
+    
+    ```json
+    {
+      "status": 403,
+      "error": "Forbidden",
+      "message": "You do not have permission to update this reservation."
+    }
+    ```
+    
+
+### **3.4 잘못된 요청 (400 Bad Request)**
+
+- **Description**: 최소 하나의 필드가 포함되어 있지 않거나 허용되지 않은 값인 경우입니다.
+    
+    ```json
+    {
+      "status": 400,
+      "error": "Bad Request",
+      "message": "At least one field must be provided."
+    }
+    ```
+    
+
+### **3.5 리소스 없음 (404 Not Found)**
+
+- **Description**: 해당 `reservationId`에 해당하는 예약이 존재하지 않는 경우입니다.
+    
+    ```json
+    {
+      "status": 404,
+      "error": "Not Found",
+      "message": "Reservation not found."
+    }
+    ```
+    
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **Resource Check**: `reservationId`로 reservations 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+4. **Authorization Check**: `itinerary_id → room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+5. **Validation**: 요청 body에 최소 하나의 필드가 포함되어 있는지 확인합니다. `status` 값이 허용된 값인지 검증합니다. 없으면 400을 반환합니다.
+6. **Update**: 요청에 포함된 필드만 업데이트하고 `updated_at`을 갱신합니다.
+
+### **4.2 DB 업데이트 구조 (reservations Table)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `status` | VARCHAR(20) | 요청에 포함된 경우 업데이트 |
+| `detail` | JSONB | 요청에 포함된 경우 업데이트 |
+| `total_price` | DECIMAL(12,2) | 요청에 포함된 경우 업데이트 |
+| `currency` | VARCHAR(3) | 요청에 포함된 경우 업데이트 |
+| `reserved_at` | TIMESTAMP | 요청에 포함된 경우 업데이트 |
+| `cancelled_at` | TIMESTAMP | 요청에 포함된 경우 업데이트 |
+| `updated_at` | TIMESTAMP | 현재 시각으로 업데이트 |
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```json
+curl -X PATCH https://your-api-domain.com/v1/reservations/{reservationId} \
+  -H "Authorization: Bearer <clerk_jwt_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "cancelled", "cancelledAt": "2026-04-10T10:00:00"}'
+```

--- a/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
+++ b/docs/api/v1/reservations/PATCH_api_v1_reservations_{reservationId}.md
@@ -1,6 +1,6 @@
 ## **[PATCH] /api/v1/reservations/{reservationId}**
 
-예약 상태 변경, detail 수정, 가격 등을 업데이트합니다.
+예약 상태 변경(취소/변경), detail 수정, 가격 등을 업데이트합니다.
 
 ---
 
@@ -10,7 +10,7 @@
 | --- | --- |
 | Method | `PATCH` |
 | URL | `/api/v1/reservations/{reservationId}` |
-| Summary | 예약 수정 |
+| Summary | 예약 수정(취소 또는 변경) |
 | Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
 
 ---
@@ -38,16 +38,16 @@
 ```json
 {
   "status": "cancelled",
-  "cancelledAt": "2026-04-10T10:00:00"
+  "cancelledAt": "2026-04-10T10:00:00+09:00"
 }
 ```
 
 | Field | Required | Type | Description |
 | --- | --- | --- | --- |
 | `status` | Y | String | `cancelled` 고정 |
-| `cancelledAt` | Y | TIMESTAMP | 취소 일시 |
+| `cancelledAt` | Y | ISO-8601 with offset | 취소 일시. **타임존 오프셋 필수** (예: `2026-04-10T10:00:00+09:00`) |
 
-**Case 2. `status: "changed"` — 예약 변경**
+**Case 2. `status: "changed"` — 예약 변경 → Swagger Request Example로 사용합니다.**
 
 ```json
 {
@@ -62,7 +62,7 @@
   },
   "totalPrice": 290000.00,
   "currency": "KRW",
-  "reservedAt": "2026-04-10T10:00:00"
+  "reservedAt": "2026-04-10T10:00:00+09:00"
 }
 ```
 
@@ -70,9 +70,9 @@
 | --- | --- | --- | --- |
 | `status` | Y | String | `changed` 고정 |
 | `detail` | Y | JSONB | 변경된 예약 상세 정보 |
-| `totalPrice` | Y | Decimal | 변경된 총 결제 금액 |
+| `totalPrice` | N | Decimal | 변경된 총 결제 금액 |
 | `currency` | N | String | 통화 코드 (기본값 `KRW`) |
-| `reservedAt` | Y | TIMESTAMP | 변경된 예약 완료 일시 |
+| `reservedAt` | Y | ISO-8601 with offset | 변경된 예약 완료 일시. **타임존 오프셋 필수** (예: `2026-04-10T10:00:00+09:00`) |
 
 ---
 
@@ -87,8 +87,8 @@
         {
           "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
           "status": "cancelled",
-          "cancelledAt": "2026-04-10T10:00:00",
-          "updatedAt": "2026-04-10T10:00:00"
+          "cancelledAt": "2026-04-10T10:00:00Z",
+          "updatedAt": "2026-04-10T10:00:00+09:00"
         }
         ```
         
@@ -98,8 +98,8 @@
         {
           "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
           "status": "changed",
-          "reservedAt": "2026-04-10T10:00:00",
-          "updatedAt": "2026-04-10T10:00:00"
+          "reservedAt": "2026-04-10T10:00:00Z",
+          "updatedAt": "2026-04-10T10:00:00+09:00"
         }
         ```
         
@@ -133,13 +133,22 @@
 ### **3.4 잘못된 요청 (400 Bad Request)**
 
 - **Description**: 필수 필드가 누락되었거나 허용되지 않은 값인 경우입니다.
+    - 수정 요청 본문이 비어있는 경우 (의미 없는 호출):
+        
+        ```json
+        {
+          "status": 400,
+          "error": "Bad Request",
+          "message": "At least one field must be provided."
+        }
+        ```
     - `status` 값이 허용되지 않은 경우:
         
         ```json
         {
           "status": 400,
           "error": "Bad Request",
-          "message": "status must be one of: cancelled, changed."
+          "message": "status must be one of: changed, cancelled."
         }
         ```
         
@@ -159,24 +168,36 @@
         {
           "status": 400,
           "error": "Bad Request",
-          "message": "detail, totalPrice, reservedAt are required when status is changed."
+          "message": "detail, reservedAt are required when status is changed."
         }
         ```
         
-    - `detail` 제공 시 예약 `type`에 맞는 필수 키가 누락된 경우 (type별 필수 필드는 POST 명세의 **4.2** 참고):
-
-      | 케이스 | message |
-      | --- | --- |
-      | `detail` 필수 키 누락 | `detail.{field} is required for type '{type}'.` |
-      | `detail` 중첩 필수 키 누락 | `detail.{parent}.{field} is required for type '{type}'.` |
-      | `passengers` 빈 배열 또는 비리스트 | `detail.passengers must be a non-empty array for type 'flight'.` |
-      | `passengers[n]` name/passport 누락 | `detail.passengers[n] must include name and passport.` |
-
+    - `detail` 제공 시 예약 `type`에 맞는 필수 키가 누락된 경우. `type`은 요청 body가 아닌 **DB의 기존 예약에서 조회**합니다 (type별 필수 필드는 POST 명세의 **4.2** 참고):
+        
+        
+        | 케이스 | message |
+        | --- | --- |
+        | `detail` 필수 키 누락 또는 빈 값 | `detail.{field} is required for type '{type}'.` |
+        | `detail.{parent}` 객체 아님 | `detail.{parent} must be an object for type '{type}'.` |
+        | `detail` 중첩 필수 키 누락 또는 빈 값 | `detail.{parent}.{field} is required for type '{type}'.` |
+        | `passengers` 빈 배열 또는 비리스트 | `detail.passengers must be a non-empty array for type 'flight'.` |
+        | `passengers[n]` name/passport 누락 또는 빈 값 | `detail.passengers[n] must include name and passport.` |
+        
         ```json
         {
           "status": 400,
           "error": "Bad Request",
           "message": "detail.departure.airport is required for type 'flight'."
+        }
+        ```
+        
+    - DB에 이미 `status: cancelled` 인 예약을 변경하려고 할 경우:
+        
+        ```json
+        {
+          "status": 400,
+          "error": "Bad Request",
+          "message": "Cannot update a reservation that has already been cancelled."
         }
         ```
         
@@ -193,6 +214,36 @@
     }
     ```
     
+### **3.6 서버 내부 오류 (500 Internal Server Error)**
+
+- **Description**: 요청은 유효하지만, 서버 내 데이터 간의 참조 관계가 깨져 있거나 데이터가 유실된 경우입니다.
+    - 예약과 연결된 **일정(Itinerary)** 데이터가 없는 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Related itinerary data is missing."
+        }
+        ```
+    - 일정과 연결된 **채팅방(ChatRoom)** 데이터가 없는 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Related chat room data is missing."
+        }
+        ```
+    - 기타 예상치 못한 서버 내부 오류 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Failed to update reservation."
+        }
+        ```
 
 ---
 
@@ -204,11 +255,12 @@
 2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
 3. **Resource Check**: `reservationId`로 reservations 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
 4. **Authorization Check**: `itinerary_id → room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
-5. **Validation**: `status` 값이 `cancelled` / `changed` 중 하나인지 확인합니다. 아니면 400을 반환합니다.
+5. **State Pre-check**: 현재 DB에 있는 예약의 `status`가 `cancelled`라면 수정을 거부하고 400을 반환합니다.
+6. **Validation**: `status` 값이 `cancelled` / `changed` 중 하나인지 확인합니다. 아니면 400을 반환합니다.
     - `status: cancelled` → `cancelledAt` 필수 확인. 누락 시 400 반환.
-    - `status: changed` → `detail`, `totalPrice`, `reservedAt` 필수 확인. 누락 시 400 반환.
-6. **Detail Validation**: `detail`이 포함된 경우, 기존 예약의 `type`에 따라 필수 키를 검증합니다. 누락된 키가 있으면 400을 반환합니다.
-7. **Update**: 요청에 포함된 필드만 업데이트하고 `updated_at`을 갱신합니다.
+    - `status: changed` → `detail`, `reservedAt` 필수 확인. 누락 시 400 반환.
+7. **Detail Validation**: `detail` 이 포함된 경우, 기존 예약의 `type` 에 따라 필수 키를 검증합니다. 누락된 키가 있으면 400을 반환합니다.
+8. **Update**: 요청에 포함된 필드만 업데이트하고 `updated_at`을 갱신합니다.
 
 ### **4.2 DB 업데이트 구조 (reservations Table)**
 
@@ -226,7 +278,7 @@
 | --- | --- | --- |
 | `status` | VARCHAR(20) | `changed`로 업데이트 |
 | `detail` | JSONB | 변경된 상세 정보로 업데이트 |
-| `total_price` | DECIMAL(12,2) | 변경된 금액으로 업데이트 |
+| `total_price` | DECIMAL(12,2) | 변경된 금액으로 업데이트 (요청에 포함된 경우만) |
 | `currency` | VARCHAR(3) | 요청에 포함된 경우 업데이트 |
 | `reserved_at` | TIMESTAMP | 변경된 예약 일시로 업데이트 |
 | `updated_at` | TIMESTAMP | 현재 시각으로 업데이트 |
@@ -237,13 +289,13 @@
 
 ```json
 # 취소
-curl -X PATCH https://your-api-domain.com/v1/reservations/{reservationId} \
+curl -X PATCH https://your-api-domain.com/api/v1/reservations/{reservationId} \
   -H "Authorization: Bearer <clerk_jwt_token>" \
   -H "Content-Type: application/json" \
   -d '{"status": "cancelled", "cancelledAt": "2026-04-10T10:00:00"}'
 
 # 변경
-curl -X PATCH https://your-api-domain.com/v1/reservations/{reservationId} \
+curl -X PATCH https://your-api-domain.com/api/v1/reservations/{reservationId} \
   -H "Authorization: Bearer <clerk_jwt_token>" \
   -H "Content-Type: application/json" \
   -d '{"status": "changed", "detail": {...}, "totalPrice": 290000.00, "reservedAt": "2026-04-10T10:00:00"}'

--- a/docs/api/v1/reservations/POST_api_v1_reservations.md
+++ b/docs/api/v1/reservations/POST_api_v1_reservations.md
@@ -108,12 +108,21 @@
 ### **3.4 잘못된 요청 (400 Bad Request)**
 
 - **Description**: 필수 필드가 누락되었거나 허용되지 않은 값인 경우입니다.
-    
+
+  | 케이스 | message |
+  | --- | --- |
+  | `type` 허용값 위반 | `type must be one of: flight, accommodation, car_rental.` |
+  | `bookedBy` 허용값 위반 | `bookedBy must be one of: user, ai.` |
+  | `detail` 필수 키 누락 | `detail.{field} is required for type '{type}'.` |
+  | `detail` 중첩 필수 키 누락 | `detail.{parent}.{field} is required for type '{type}'.` |
+  | `passengers` 빈 배열 또는 비리스트 | `detail.passengers must be a non-empty array for type 'flight'.` |
+  | `passengers[n]` name/passport 누락 | `detail.passengers[n] must include name and passport.` |
+
     ```json
     {
       "status": 400,
       "error": "Bad Request",
-      "message": "type must be one of: flight, accommodation, car_rental."
+      "message": "detail.departure.airport is required for type 'flight'."
     }
     ```
     
@@ -142,9 +151,47 @@
 3. **Resource Check**: `itineraryId`로 itineraries 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
 4. **Authorization Check**: `room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
 5. **Validation**: `type`, `bookedBy` 값이 허용된 값인지 검증합니다. 허용되지 않은 값이면 400을 반환합니다.
-6. **Insert**: `reservations` 테이블에 레코드를 생성합니다. `status`는 `confirmed`로 초기화합니다.
+6. **Detail Validation**: `type`에 따라 `detail` 필수 키를 검증합니다. 누락된 키가 있으면 400을 반환합니다.
+7. **Insert**: `reservations` 테이블에 레코드를 생성합니다. `status`는 `confirmed`로 초기화합니다.
 
-### **4.2 DB 저장 구조 (reservations Table)**
+### **4.2 detail 필수 필드 (type별)**
+
+**flight**
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `airline` | String | 항공사명 |
+| `flight_no` | String | 편명 |
+| `departure.airport` | String | 출발 공항 코드 |
+| `departure.datetime` | String | 출발 일시 |
+| `arrival.airport` | String | 도착 공항 코드 |
+| `arrival.datetime` | String | 도착 일시 |
+| `seat_class` | String | 좌석 등급 |
+| `passengers[].name` | String | 탑승객 이름 |
+| `passengers[].passport` | String | 탑승객 여권번호 |
+
+**accommodation**
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `hotel_name` | String | 숙소명 |
+| `room_type` | String | 객실 유형 |
+| `check_in` | String | 체크인 날짜 |
+| `check_out` | String | 체크아웃 날짜 |
+| `guests` | Number | 투숙 인원 |
+
+**car_rental**
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `company` | String | 렌터카 업체명 |
+| `car_model` | String | 차량 모델 |
+| `pickup.location` | String | 픽업 장소 |
+| `pickup.datetime` | String | 픽업 일시 |
+| `dropoff.location` | String | 반납 장소 |
+| `dropoff.datetime` | String | 반납 일시 |
+
+### **4.3 DB 저장 구조 (reservations Table)**
 
 | Column | Type | Description |
 | --- | --- | --- |

--- a/docs/api/v1/reservations/POST_api_v1_reservations.md
+++ b/docs/api/v1/reservations/POST_api_v1_reservations.md
@@ -1,0 +1,176 @@
+## **[POST] /api/v1/reservations**
+
+예약 링크 제공 시 예약 레코드를 생성합니다.
+
+---
+
+### **1. 기본 정보**
+
+| 항목 | 내용 |
+| --- | --- |
+| Method | `POST` |
+| URL | `/api/v1/reservations` |
+| Summary | 예약 생성 |
+| Authentication | Bearer JWT (Clerk 발급 토큰 필수) |
+
+---
+
+### **2. 요청 (Request)**
+
+### **2.1 Headers**
+
+| Name | Required | Example | Description |
+| --- | --- | --- | --- |
+| Authorization | Y | `Bearer eyJhbGci...` | Clerk에서 발급받은 유효한 JWT 토큰 |
+
+### **2.2 Body**
+
+```json
+{
+  "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+  "type": "flight",
+  "bookedBy": "ai",
+  "bookingUrl": "https://booking.example.com/flight/123",
+  "externalRefId": "KE12345678",
+  "detail": {
+    "airline": "대한항공",
+    "flight_no": "KE123",
+    "departure": {"airport": "ICN", "datetime": "2026-05-01T09:00:00"},
+    "arrival": {"airport": "NRT", "datetime": "2026-05-01T11:30:00"},
+    "seat_class": "economy",
+    "passengers": [{"name": "홍길동", "passport": "M12345678"}]
+  },
+  "totalPrice": 320000.00,
+  "currency": "KRW",
+  "reservedAt": "2026-04-03T21:30:00"
+}
+```
+
+| Field | Required | Type | Description |
+| --- | --- | --- | --- |
+| `itineraryId` | Y | UUID | 연결된 일정 ID |
+| `type` | Y | String | `flight` | `accommodation` | `car_rental` |
+| `bookedBy` | Y | String | `user` | `ai` |
+| `bookingUrl` | N | String | 예약 링크 |
+| `externalRefId` | N | String | 외부 예약 번호 |
+| `detail` | Y | JSONB | 유형별 상세 정보 |
+| `totalPrice` | N | Decimal | 총 결제 금액 |
+| `currency` | N | String | 통화 코드 (기본값 `KRW`) |
+| `reservedAt` | N | TIMESTAMP | 예약 완료 일시 |
+
+---
+
+### **3. 응답 (Response)**
+
+### **3.1 성공 (201 Created)**
+
+- **Description**: 예약이 성공적으로 생성되었습니다.
+    
+    ```json
+    {
+      "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
+      "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+      "type": "flight",
+      "status": "confirmed",
+      "createdAt": "2026-04-03T21:20:00"
+    }
+    ```
+    
+
+### **3.2 인증 실패 (401 Unauthorized)**
+
+- **Description**: JWT 토큰이 누락되었거나 만료, 서명 오류 등으로 유효하지 않은 경우입니다.
+    
+    ```json
+    {
+      "status": 401,
+      "error": "Unauthorized",
+      "message": "Invalid or expired token."
+    }
+    ```
+    
+
+### **3.3 권한 없음 (403 Forbidden)**
+
+- **Description**: 해당 일정의 소유자가 아닌 경우입니다.
+    
+    ```json
+    {
+      "status": 403,
+      "error": "Forbidden",
+      "message": "You do not have permission to create a reservation for this itinerary."
+    }
+    ```
+    
+
+### **3.4 잘못된 요청 (400 Bad Request)**
+
+- **Description**: 필수 필드가 누락되었거나 허용되지 않은 값인 경우입니다.
+    
+    ```json
+    {
+      "status": 400,
+      "error": "Bad Request",
+      "message": "type must be one of: flight, accommodation, car_rental."
+    }
+    ```
+    
+
+### **3.5 리소스 없음 (404 Not Found)**
+
+- **Description**: 해당 `itineraryId`에 해당하는 일정이 존재하지 않는 경우입니다.
+    
+    ```json
+    {
+      "status": 404,
+      "error": "Not Found",
+      "message": "Itinerary not found."
+    }
+    ```
+    
+
+---
+
+### **4. 비즈니스 로직 및 DB 스키마**
+
+### **4.1 동작 흐름 (Sequence)**
+
+1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
+2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
+3. **Resource Check**: `itineraryId`로 itineraries 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+4. **Authorization Check**: `room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+5. **Validation**: `type`, `bookedBy` 값이 허용된 값인지 검증합니다. 허용되지 않은 값이면 400을 반환합니다.
+6. **Insert**: `reservations` 테이블에 레코드를 생성합니다. `status`는 `confirmed`로 초기화합니다.
+
+### **4.2 DB 저장 구조 (reservations Table)**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `itinerary_id` | UUID | 연결된 일정 ID |
+| `type` | VARCHAR(20) | 예약 유형 |
+| `status` | VARCHAR(20) | `confirmed` 로 초기화 |
+| `booked_by` | VARCHAR(10) | 예약 주체 |
+| `booking_url` | TEXT | 예약 링크 |
+| `external_ref_id` | VARCHAR(255) | 외부 예약 번호 |
+| `detail` | JSONB | 유형별 상세 정보 |
+| `total_price` | DECIMAL(12,2) | 총 결제 금액 |
+| `currency` | VARCHAR(3) | 통화 코드 |
+| `reserved_at` | TIMESTAMP | 예약 완료 일시 |
+
+---
+
+### **5. 호출 예시 (Example)**
+
+```bash
+curl -X POST https://your-api-domain.com/v1/reservations \
+  -H "Authorization: Bearer <clerk_jwt_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+    "type": "flight",
+    "bookedBy": "ai",
+    "bookingUrl": "https://booking.example.com/flight/123",
+    "detail": {...},
+    "totalPrice": 320000.00
+  }'
+```

--- a/docs/api/v1/reservations/POST_api_v1_reservations.md
+++ b/docs/api/v1/reservations/POST_api_v1_reservations.md
@@ -42,7 +42,7 @@
   },
   "totalPrice": 320000.00,
   "currency": "KRW",
-  "reservedAt": "2026-04-03T21:20:00"
+  "reservedAt": "2026-04-03T21:20:00+09:00"
 }
 ```
 
@@ -56,7 +56,7 @@
 | `detail` | Y | JSONB | 유형별 상세 정보 |
 | `totalPrice` | N | Decimal | 총 결제 금액 |
 | `currency` | N | String | 통화 코드 (기본값 `KRW`) |
-| `reservedAt` | N | TIMESTAMP | 예약 완료 일시 |
+| `reservedAt` | N | ISO-8601 with offset | 예약 완료 일시. **타임존 오프셋 필수** (예: `2026-04-03T21:20:00+09:00`) |
 
 ---
 
@@ -72,9 +72,9 @@
       "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
       "type": "flight",
       "status": "confirmed",
-      "reservedAt": "2026-04-03T21:20:00",
-      "createdAt": "2026-04-03T21:20:10",
-      "updatedAt": "2026-04-03T21:20:10"
+      "reservedAt": "2026-04-03T21:20:00Z",
+      "createdAt": "2026-04-03T12:20:10+09:00",
+      "updatedAt": "2026-04-03T12:20:10+09:00"
     }
     ```
     
@@ -108,16 +108,34 @@
 ### **3.4 잘못된 요청 (400 Bad Request)**
 
 - **Description**: 필수 필드가 누락되었거나 허용되지 않은 값인 경우입니다.
-
-  | 케이스 | message |
-  | --- | --- |
-  | `type` 허용값 위반 | `type must be one of: flight, accommodation, car_rental.` |
-  | `bookedBy` 허용값 위반 | `bookedBy must be one of: user, ai.` |
-  | `detail` 필수 키 누락 | `detail.{field} is required for type '{type}'.` |
-  | `detail` 중첩 필수 키 누락 | `detail.{parent}.{field} is required for type '{type}'.` |
-  | `passengers` 빈 배열 또는 비리스트 | `detail.passengers must be a non-empty array for type 'flight'.` |
-  | `passengers[n]` name/passport 누락 | `detail.passengers[n] must include name and passport.` |
-
+    
+    
+    | 케이스 | message |
+    | --- | --- |
+    | `type` 허용값 위반 | `type must be one of: flight, accommodation, car_rental.` |
+    | `bookedBy` 허용값 위반 | `bookedBy must be one of: user, ai.` |
+    | `detail` 필수 키 누락 또는 빈 값 | `detail.{field} is required for type '{type}'.` |
+    | `detail.{parent}` 객체 아님 | `detail.{parent} must be an object for type '{type}'.` |
+    | `detail` 중첩 필수 키 누락 또는 빈 값 | `detail.{parent}.{field} is required for type '{type}'.` |
+    | `passengers` 빈 배열 또는 비리스트 | `detail.passengers must be a non-empty array for type 'flight'.` |
+    | `passengers[n]` name/passport 누락 또는 빈 값 | `detail.passengers[n] must include name and passport.` |
+    
+    ```json
+    {
+    	"status": 400,
+    	"error": "Bad Request",
+    	"message": "type must be one of: flight, accommodation, car_rental."
+    }
+    ```
+    
+    ```json
+    {
+    	"status": 400,
+    	"error": "Bad Request",
+    	"message": "bookedBy must be one of: user, ai."
+    }
+    ```
+    
     ```json
     {
       "status": 400,
@@ -129,8 +147,16 @@
 
 ### **3.5 리소스 없음 (404 Not Found)**
 
-- **Description**: 해당 `itineraryId`에 해당하는 일정이 존재하지 않는 경우입니다.
-    
+- **Description**: JWT는 유효하지만 서비스 DB에 해당 사용자가 존재하지 않거나, `itineraryId`에 해당하는 일정이 존재하지 않는 경우입니다.
+
+    ```json
+    {
+      "status": 404,
+      "error": "Not Found",
+      "message": "User not found. Please sign up first."
+    }
+    ```
+
     ```json
     {
       "status": 404,
@@ -139,6 +165,27 @@
     }
     ```
     
+### **3.6 서버 내부 오류 (500 Internal Server Error)**
+
+- **Description**: 요청은 유효하지만, 서버 내 데이터 간의 참조 관계가 깨져 있거나 데이터가 유실된 경우입니다.
+    - 일정과 연결된 **채팅방(ChatRoom)** 데이터가 없는 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Related chat room data is missing."
+        }
+        ```
+    - 기타 예상치 못한 서버 내부 오류 경우:
+        
+        ```json
+        {
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "Failed to create reservation."
+        }
+        ```
 
 ---
 
@@ -148,11 +195,12 @@
 
 1. **Token Parsing**: Authorization 헤더에서 JWT를 추출하고 검증합니다.
 2. **Claim Extraction**: JWT의 `sub` 클레임을 추출하여 `clerk_id`로 사용합니다.
-3. **Resource Check**: `itineraryId`로 itineraries 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
-4. **Authorization Check**: `room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
-5. **Validation**: `type`, `bookedBy` 값이 허용된 값인지 검증합니다. 허용되지 않은 값이면 400을 반환합니다.
-6. **Detail Validation**: `type`에 따라 `detail` 필수 키를 검증합니다. 누락된 키가 있으면 400을 반환합니다.
-7. **Insert**: `reservations` 테이블에 레코드를 생성합니다. `status`는 `confirmed`로 초기화합니다.
+3. **User Check**: `users` 테이블에서 해당 `clerk_id` 사용자가 존재하는지 확인합니다. 존재하지 않으면 404를 반환합니다.
+4. **Validation**: `type`, `bookedBy` 값이 허용된 값인지 검증합니다. 허용되지 않은 값이면 400을 반환합니다.
+5. **Resource Check**: `itineraryId`로 itineraries 테이블을 조회합니다. 존재하지 않으면 404를 반환합니다.
+6. **Authorization Check**: `room_id → chat_rooms.clerk_id`가 요청자의 `clerk_id`와 일치하는지 확인합니다. 일치하지 않으면 403을 반환합니다.
+7. **Detail Validation**: `type`에 따라 `detail` 필수 키를 검증합니다. 누락 또는 빈 값이면 400을 반환합니다.
+8. **Insert**: `reservations` 테이블에 레코드를 생성합니다. `status`는 `confirmed`로 초기화합니다.
 
 ### **4.2 detail 필수 필드 (type별)**
 
@@ -211,7 +259,7 @@
 ### **5. 호출 예시 (Example)**
 
 ```bash
-curl -X POST https://your-api-domain.com/v1/reservations \
+curl -X POST https://your-api-domain.com/api/v1/reservations \
   -H "Authorization: Bearer <clerk_jwt_token>" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/api/v1/reservations/POST_api_v1_reservations.md
+++ b/docs/api/v1/reservations/POST_api_v1_reservations.md
@@ -42,7 +42,7 @@
   },
   "totalPrice": 320000.00,
   "currency": "KRW",
-  "reservedAt": "2026-04-03T21:30:00"
+  "reservedAt": "2026-04-03T21:20:00"
 }
 ```
 

--- a/docs/api/v1/reservations/POST_api_v1_reservations.md
+++ b/docs/api/v1/reservations/POST_api_v1_reservations.md
@@ -72,7 +72,9 @@
       "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
       "type": "flight",
       "status": "confirmed",
-      "createdAt": "2026-04-03T21:20:00"
+      "reservedAt": "2026-04-03T21:20:00",
+      "createdAt": "2026-04-03T21:20:10",
+      "updatedAt": "2026-04-03T21:20:10"
     }
     ```
     

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
@@ -1,9 +1,12 @@
 package com.mju.capstone_backend.domain.reservation.controller;
 
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -27,5 +30,15 @@ public class ReservationController {
             JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();
         return reservationService.getReservations(clerkId, type, status);
+    }
+
+    @Operation(summary = "예약 생성", description = "AI Agent가 예약 링크 제공 시 예약 레코드를 생성합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<CreateReservationResponse> createReservation(
+            @Valid @RequestBody CreateReservationRequest request,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return reservationService.createReservation(clerkId, request);
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.reservation.controller;
 
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.DeleteReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
@@ -59,8 +60,8 @@ public class ReservationController {
 
     @Operation(summary = "예약 삭제", description = "예약 레코드를 완전히 삭제합니다. (데이터 Hard Delete)")
     @DeleteMapping("/{reservationId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public Mono<Void> deleteReservation(
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<DeleteReservationResponse> deleteReservation(
             @PathVariable UUID reservationId,
             JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
@@ -3,6 +3,8 @@ package com.mju.capstone_backend.domain.reservation.controller;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
 import com.mju.capstone_backend.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @Tag(name = "Reservation API", description = "예약 관련 API")
 @RestController
@@ -40,5 +44,16 @@ public class ReservationController {
             JwtAuthenticationToken authentication) {
         String clerkId = authentication.getToken().getSubject();
         return reservationService.createReservation(clerkId, request);
+    }
+
+    @Operation(summary = "예약 수정", description = "예약 상태, detail, 가격 등을 수정합니다.")
+    @PatchMapping("/{reservationId}")
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<PatchReservationResponse> updateReservation(
+            @PathVariable UUID reservationId,
+            @RequestBody PatchReservationRequest request,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return reservationService.updateReservation(clerkId, reservationId, request);
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
@@ -1,0 +1,31 @@
+package com.mju.capstone_backend.domain.reservation.controller;
+
+import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Reservation API", description = "예약 관련 API")
+@RestController
+@RequestMapping("/api/v1/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @Operation(summary = "내 예약 목록 조회", description = "현재 로그인한 사용자의 예약 목록을 조회합니다. type과 status로 필터링할 수 있습니다.")
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<GetReservationsResponse> getReservations(
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String status,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return reservationService.getReservations(clerkId, type, status);
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
@@ -57,7 +57,7 @@ public class ReservationController {
         return reservationService.updateReservation(clerkId, reservationId, request);
     }
 
-    @Operation(summary = "예약 삭제", description = "예약 레코드를 완전히 삭제합니다.")
+    @Operation(summary = "예약 삭제", description = "예약 레코드를 완전히 삭제합니다. (데이터 Hard Delete)")
     @DeleteMapping("/{reservationId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> deleteReservation(

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/controller/ReservationController.java
@@ -56,4 +56,14 @@ public class ReservationController {
         String clerkId = authentication.getToken().getSubject();
         return reservationService.updateReservation(clerkId, reservationId, request);
     }
+
+    @Operation(summary = "예약 삭제", description = "예약 레코드를 완전히 삭제합니다.")
+    @DeleteMapping("/{reservationId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> deleteReservation(
+            @PathVariable UUID reservationId,
+            JwtAuthenticationToken authentication) {
+        String clerkId = authentication.getToken().getSubject();
+        return reservationService.deleteReservation(clerkId, reservationId);
+    }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CancelReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CancelReservationResponse.java
@@ -1,0 +1,22 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CancelReservationResponse(
+        UUID reservationId,
+        String status,
+        OffsetDateTime cancelledAt,
+        OffsetDateTime updatedAt
+) implements PatchReservationResponse {
+    public static CancelReservationResponse from(Reservation reservation) {
+        return new CancelReservationResponse(
+                reservation.getId(),
+                reservation.getStatus(),
+                reservation.getCancelledAt(),
+                reservation.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/ChangeReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/ChangeReservationResponse.java
@@ -1,0 +1,22 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ChangeReservationResponse(
+        UUID reservationId,
+        String status,
+        OffsetDateTime reservedAt,
+        OffsetDateTime updatedAt
+) implements PatchReservationResponse {
+    public static ChangeReservationResponse from(Reservation reservation) {
+        return new ChangeReservationResponse(
+                reservation.getId(),
+                reservation.getStatus(),
+                reservation.getReservedAt(),
+                reservation.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationRequest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
           },
           "totalPrice": 320000.00,
           "currency": "KRW",
-          "reservedAt": "2026-04-03T21:30:00+09:00"
+          "reservedAt": "2026-04-03T21:20:00"
         }
         """)
 public record CreateReservationRequest(

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationRequest.java
@@ -1,0 +1,43 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Schema(example = """
+        {
+          "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
+          "type": "flight",
+          "bookedBy": "ai",
+          "bookingUrl": "https://booking.example.com/flight/123",
+          "externalRefId": "KE12345678",
+          "detail": {
+            "airline": "대한항공",
+            "flight_no": "KE123",
+            "departure": {"airport": "ICN", "datetime": "2026-05-01T09:00:00"},
+            "arrival": {"airport": "NRT", "datetime": "2026-05-01T11:30:00"},
+            "seat_class": "economy",
+            "passengers": [{"name": "홍길동", "passport": "M12345678"}]
+          },
+          "totalPrice": 320000.00,
+          "currency": "KRW",
+          "reservedAt": "2026-04-03T21:30:00+09:00"
+        }
+        """)
+public record CreateReservationRequest(
+        @NotNull UUID itineraryId,
+        @NotBlank String type,
+        @NotBlank String bookedBy,
+        String bookingUrl,
+        String externalRefId,
+        @NotNull Map<String, Object> detail,
+        BigDecimal totalPrice,
+        String currency,
+        OffsetDateTime reservedAt
+) {
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationRequest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
           },
           "totalPrice": 320000.00,
           "currency": "KRW",
-          "reservedAt": "2026-04-03T21:20:00"
+          "reservedAt": "2026-04-03T21:20:00+09:00"
         }
         """)
 public record CreateReservationRequest(

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationResponse.java
@@ -10,7 +10,9 @@ public record CreateReservationResponse(
         UUID itineraryId,
         String type,
         String status,
-        OffsetDateTime createdAt
+        OffsetDateTime reservedAt,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
 ) {
     public static CreateReservationResponse from(Reservation reservation) {
         return new CreateReservationResponse(
@@ -18,7 +20,9 @@ public record CreateReservationResponse(
                 reservation.getItineraryId(),
                 reservation.getType(),
                 reservation.getStatus(),
-                reservation.getCreatedAt()
+                reservation.getReservedAt(),
+                reservation.getCreatedAt(),
+                reservation.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/CreateReservationResponse.java
@@ -1,0 +1,24 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CreateReservationResponse(
+        UUID reservationId,
+        UUID itineraryId,
+        String type,
+        String status,
+        OffsetDateTime createdAt
+) {
+    public static CreateReservationResponse from(Reservation reservation) {
+        return new CreateReservationResponse(
+                reservation.getId(),
+                reservation.getItineraryId(),
+                reservation.getType(),
+                reservation.getStatus(),
+                reservation.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/DeleteReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/DeleteReservationResponse.java
@@ -1,0 +1,12 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import java.util.UUID;
+
+public record DeleteReservationResponse(
+        UUID reservationId,
+        boolean deleted
+) {
+    public static DeleteReservationResponse of(UUID reservationId) {
+        return new DeleteReservationResponse(reservationId, true);
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/GetReservationsResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/GetReservationsResponse.java
@@ -1,0 +1,48 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record GetReservationsResponse(List<ReservationDto> reservations) {
+
+    public record ReservationDto(
+            UUID reservationId,
+            UUID itineraryId,
+            String type,
+            String status,
+            String bookedBy,
+            String bookingUrl,
+            String externalRefId,
+            Map<String, Object> detail,
+            BigDecimal totalPrice,
+            String currency,
+            OffsetDateTime reservedAt,
+            OffsetDateTime cancelledAt,
+            OffsetDateTime createdAt,
+            OffsetDateTime updatedAt
+    ) {
+        public static ReservationDto from(Reservation reservation, Map<String, Object> detail) {
+            return new ReservationDto(
+                    reservation.getId(),
+                    reservation.getItineraryId(),
+                    reservation.getType(),
+                    reservation.getStatus(),
+                    reservation.getBookedBy(),
+                    reservation.getBookingUrl(),
+                    reservation.getExternalRefId(),
+                    detail,
+                    reservation.getTotalPrice(),
+                    reservation.getCurrency(),
+                    reservation.getReservedAt(),
+                    reservation.getCancelledAt(),
+                    reservation.getCreatedAt(),
+                    reservation.getUpdatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationRequest.java
@@ -1,0 +1,27 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+@Schema(example = """
+        {
+          "status": "cancelled",
+          "cancelledAt": "2026-04-10T10:00:00+09:00"
+        }
+        """)
+public record PatchReservationRequest(
+        String status,
+        Map<String, Object> detail,
+        BigDecimal totalPrice,
+        String currency,
+        OffsetDateTime reservedAt,
+        OffsetDateTime cancelledAt
+) {
+    public boolean isEmpty() {
+        return status == null && detail == null && totalPrice == null
+                && currency == null && reservedAt == null && cancelledAt == null;
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationRequest.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationRequest.java
@@ -8,8 +8,18 @@ import java.util.Map;
 
 @Schema(example = """
         {
-          "status": "cancelled",
-          "cancelledAt": "2026-04-10T10:00:00+09:00"
+          "status": "changed",
+          "detail": {
+            "airline": "아시아나",
+            "flight_no": "OZ108",
+            "departure": {"airport": "ICN", "datetime": "2026-05-02T09:00:00"},
+            "arrival": {"airport": "NRT", "datetime": "2026-05-02T11:30:00"},
+            "seat_class": "economy",
+            "passengers": [{"name": "홍길동", "passport": "M12345678"}]
+          },
+          "totalPrice": 290000.00,
+          "currency": "KRW",
+          "reservedAt": "2026-04-10T10:00:00+09:00"
         }
         """)
 public record PatchReservationRequest(

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationResponse.java
@@ -1,0 +1,20 @@
+package com.mju.capstone_backend.domain.reservation.dto;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PatchReservationResponse(
+        UUID reservationId,
+        String status,
+        OffsetDateTime updatedAt
+) {
+    public static PatchReservationResponse from(Reservation reservation) {
+        return new PatchReservationResponse(
+                reservation.getId(),
+                reservation.getStatus(),
+                reservation.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationResponse.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/dto/PatchReservationResponse.java
@@ -1,20 +1,13 @@
 package com.mju.capstone_backend.domain.reservation.dto;
 
-import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import java.time.OffsetDateTime;
-import java.util.UUID;
-
-public record PatchReservationResponse(
-        UUID reservationId,
-        String status,
-        OffsetDateTime updatedAt
-) {
-    public static PatchReservationResponse from(Reservation reservation) {
-        return new PatchReservationResponse(
-                reservation.getId(),
-                reservation.getStatus(),
-                reservation.getUpdatedAt()
-        );
-    }
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({
+        @JsonSubTypes.Type(CancelReservationResponse.class),
+        @JsonSubTypes.Type(ChangeReservationResponse.class)
+})
+public sealed interface PatchReservationResponse
+        permits CancelReservationResponse, ChangeReservationResponse {
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
@@ -61,7 +62,8 @@ public class Reservation {
     @Column(name = "created_at", insertable = false, updatable = false)
     private OffsetDateTime createdAt;
 
-    @Column(name = "updated_at", insertable = false)
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private OffsetDateTime updatedAt;
 
     public static Reservation of(UUID itineraryId, String type, String status, String bookedBy,
@@ -78,6 +80,7 @@ public class Reservation {
         r.totalPrice = totalPrice;
         r.currency = currency;
         r.reservedAt = reservedAt;
+        r.updatedAt = OffsetDateTime.now();
         return r;
     }
 

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -56,6 +57,7 @@ public class Reservation {
     @Column(name = "cancelled_at")
     private OffsetDateTime cancelledAt;
 
+    @CreationTimestamp
     @Column(name = "created_at", insertable = false, updatable = false)
     private OffsetDateTime createdAt;
 
@@ -63,8 +65,8 @@ public class Reservation {
     private OffsetDateTime updatedAt;
 
     public static Reservation of(UUID itineraryId, String type, String status, String bookedBy,
-                                 String bookingUrl, String externalRefId, String detail,
-                                 BigDecimal totalPrice, String currency, OffsetDateTime reservedAt) {
+            String bookingUrl, String externalRefId, String detail,
+            BigDecimal totalPrice, String currency, OffsetDateTime reservedAt) {
         Reservation r = new Reservation();
         r.itineraryId = itineraryId;
         r.type = type;
@@ -80,13 +82,19 @@ public class Reservation {
     }
 
     public void update(String status, String detail, BigDecimal totalPrice,
-                       String currency, OffsetDateTime reservedAt, OffsetDateTime cancelledAt) {
-        if (status != null) this.status = status;
-        if (detail != null) this.detail = detail;
-        if (totalPrice != null) this.totalPrice = totalPrice;
-        if (currency != null) this.currency = currency;
-        if (reservedAt != null) this.reservedAt = reservedAt;
-        if (cancelledAt != null) this.cancelledAt = cancelledAt;
+            String currency, OffsetDateTime reservedAt, OffsetDateTime cancelledAt) {
+        if (status != null)
+            this.status = status;
+        if (detail != null)
+            this.detail = detail;
+        if (totalPrice != null)
+            this.totalPrice = totalPrice;
+        if (currency != null)
+            this.currency = currency;
+        if (reservedAt != null)
+            this.reservedAt = reservedAt;
+        if (cancelledAt != null)
+            this.cancelledAt = cancelledAt;
     }
 
     @PreUpdate

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
@@ -79,6 +79,16 @@ public class Reservation {
         return r;
     }
 
+    public void update(String status, String detail, BigDecimal totalPrice,
+                       String currency, OffsetDateTime reservedAt, OffsetDateTime cancelledAt) {
+        if (status != null) this.status = status;
+        if (detail != null) this.detail = detail;
+        if (totalPrice != null) this.totalPrice = totalPrice;
+        if (currency != null) this.currency = currency;
+        if (reservedAt != null) this.reservedAt = reservedAt;
+        if (cancelledAt != null) this.cancelledAt = cancelledAt;
+    }
+
     @PreUpdate
     void onUpdate() {
         this.updatedAt = OffsetDateTime.now();

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/entity/Reservation.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -38,6 +40,7 @@ public class Reservation {
     @Column(name = "external_ref_id")
     private String externalRefId;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "detail", columnDefinition = "jsonb", nullable = false)
     private String detail;
 
@@ -56,6 +59,28 @@ public class Reservation {
     @Column(name = "created_at", insertable = false, updatable = false)
     private OffsetDateTime createdAt;
 
-    @Column(name = "updated_at", insertable = false, updatable = false)
+    @Column(name = "updated_at", insertable = false)
     private OffsetDateTime updatedAt;
+
+    public static Reservation of(UUID itineraryId, String type, String status, String bookedBy,
+                                 String bookingUrl, String externalRefId, String detail,
+                                 BigDecimal totalPrice, String currency, OffsetDateTime reservedAt) {
+        Reservation r = new Reservation();
+        r.itineraryId = itineraryId;
+        r.type = type;
+        r.status = status;
+        r.bookedBy = bookedBy;
+        r.bookingUrl = bookingUrl;
+        r.externalRefId = externalRefId;
+        r.detail = detail;
+        r.totalPrice = totalPrice;
+        r.currency = currency;
+        r.reservedAt = reservedAt;
+        return r;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/repository/ReservationRepository.java
@@ -1,11 +1,36 @@
 package com.mju.capstone_backend.domain.reservation.repository;
 
 import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
 
     boolean existsByItineraryId(UUID itineraryId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Reservation r WHERE r.itineraryId = :itineraryId")
+    void deleteAllByItineraryId(@Param("itineraryId") UUID itineraryId);
+
+    @Query(value = """
+            SELECT r.* FROM reservations r
+            INNER JOIN itineraries i ON r.itinerary_id = i.id
+            INNER JOIN chat_rooms cr ON i.room_id = cr.id
+            WHERE cr.clerk_id = :clerkId
+            AND (:type IS NULL OR r.type = :type)
+            AND (:status IS NULL OR r.status = :status)
+            ORDER BY r.updated_at DESC
+            """, nativeQuery = true)
+    List<Reservation> findByClerkIdWithFilters(
+            @Param("clerkId") String clerkId,
+            @Param("type") String type,
+            @Param("status") String status
+    );
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
@@ -1,0 +1,9 @@
+package com.mju.capstone_backend.domain.reservation.service;
+
+import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import reactor.core.publisher.Mono;
+
+public interface ReservationService {
+
+    Mono<GetReservationsResponse> getReservations(String clerkId, String type, String status);
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.reservation.service;
 
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.DeleteReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
@@ -17,5 +18,5 @@ public interface ReservationService {
 
     Mono<PatchReservationResponse> updateReservation(String clerkId, UUID reservationId, PatchReservationRequest request);
 
-    Mono<Void> deleteReservation(String clerkId, UUID reservationId);
+    Mono<DeleteReservationResponse> deleteReservation(String clerkId, UUID reservationId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
@@ -16,4 +16,6 @@ public interface ReservationService {
     Mono<CreateReservationResponse> createReservation(String clerkId, CreateReservationRequest request);
 
     Mono<PatchReservationResponse> updateReservation(String clerkId, UUID reservationId, PatchReservationRequest request);
+
+    Mono<Void> deleteReservation(String clerkId, UUID reservationId);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
@@ -1,9 +1,13 @@
 package com.mju.capstone_backend.domain.reservation.service;
 
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import reactor.core.publisher.Mono;
 
 public interface ReservationService {
 
     Mono<GetReservationsResponse> getReservations(String clerkId, String type, String status);
+
+    Mono<CreateReservationResponse> createReservation(String clerkId, CreateReservationRequest request);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationService.java
@@ -3,11 +3,17 @@ package com.mju.capstone_backend.domain.reservation.service;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 public interface ReservationService {
 
     Mono<GetReservationsResponse> getReservations(String clerkId, String type, String status);
 
     Mono<CreateReservationResponse> createReservation(String clerkId, CreateReservationRequest request);
+
+    Mono<PatchReservationResponse> updateReservation(String clerkId, UUID reservationId, PatchReservationRequest request);
 }

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -35,6 +35,7 @@ public class ReservationServiceImpl implements ReservationService {
 
     private static final Set<String> VALID_TYPES = Set.of("flight", "accommodation", "car_rental");
     private static final Set<String> VALID_STATUSES = Set.of("confirmed", "changed", "cancelled");
+    private static final Set<String> VALID_PATCH_STATUSES = Set.of("changed", "cancelled");
     private static final Set<String> VALID_BOOKED_BY = Set.of("user", "ai");
 
     private final UserRepository userRepository;
@@ -71,7 +72,7 @@ public class ReservationServiceImpl implements ReservationService {
         }).subscribeOn(dbScheduler)
                 .onErrorMap(
                         e -> !(e instanceof ResponseStatusException),
-                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch reservations.")
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to get reservations.")
                 );
     }
 
@@ -96,7 +97,7 @@ public class ReservationServiceImpl implements ReservationService {
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Itinerary not found."));
 
             var chatRoom = chatRoomRepository.findById(itinerary.getRoomId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Itinerary not found."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Related chat room data is missing."));
 
             if (!chatRoom.getClerkId().equals(clerkId)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN,
@@ -136,7 +137,7 @@ public class ReservationServiceImpl implements ReservationService {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one field must be provided.");
             }
 
-            if (request.status() != null && !VALID_STATUSES.contains(request.status())) {
+            if (request.status() != null && !VALID_PATCH_STATUSES.contains(request.status())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "status must be one of: changed, cancelled.");
             }
@@ -145,10 +146,10 @@ public class ReservationServiceImpl implements ReservationService {
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
 
             Itinerary itinerary = itineraryRepository.findById(reservation.getItineraryId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Related itinerary data is missing."));
 
             var chatRoom = chatRoomRepository.findById(itinerary.getRoomId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Related chat room data is missing."));
 
             if (!chatRoom.getClerkId().equals(clerkId)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN,
@@ -206,10 +207,10 @@ public class ReservationServiceImpl implements ReservationService {
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
 
             Itinerary itinerary = itineraryRepository.findById(reservation.getItineraryId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Related itinerary data is missing."));
 
             var chatRoom = chatRoomRepository.findById(itinerary.getRoomId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Related chat room data is missing."));
 
             if (!chatRoom.getClerkId().equals(clerkId)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN,

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -172,6 +172,32 @@ public class ReservationServiceImpl implements ReservationService {
                 );
     }
 
+    @Override
+    public Mono<Void> deleteReservation(String clerkId, UUID reservationId) {
+        return Mono.fromCallable(() -> {
+            Reservation reservation = reservationRepository.findById(reservationId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+            Itinerary itinerary = itineraryRepository.findById(reservation.getItineraryId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+            var chatRoom = chatRoomRepository.findById(itinerary.getRoomId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+            if (!chatRoom.getClerkId().equals(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to delete this reservation.");
+            }
+
+            reservationRepository.delete(reservation);
+            return null;
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete reservation.")
+                ).then();
+    }
+
     private Map<String, Object> parseDetail(Reservation reservation) {
         try {
             return objectMapper.readValue(reservation.getDetail(), new TypeReference<>() {});

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -7,6 +7,7 @@ import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
 import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.DeleteReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
@@ -179,7 +180,7 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     @Override
-    public Mono<Void> deleteReservation(String clerkId, UUID reservationId) {
+    public Mono<DeleteReservationResponse> deleteReservation(String clerkId, UUID reservationId) {
         return Mono.fromCallable(() -> {
             Reservation reservation = reservationRepository.findById(reservationId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
@@ -196,12 +197,12 @@ public class ReservationServiceImpl implements ReservationService {
             }
 
             reservationRepository.delete(reservation);
-            return null;
+            return DeleteReservationResponse.of(reservationId);
         }).subscribeOn(dbScheduler)
                 .onErrorMap(
                         e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete reservation.")
-                ).then();
+                );
     }
 
     private void validateDetail(String type, Map<String, Object> detail) {
@@ -246,7 +247,6 @@ public class ReservationServiceImpl implements ReservationService {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void requirePassengers(Map<String, Object> detail) {
         Object val = detail.get("passengers");
         if (!(val instanceof List<?> list) || list.isEmpty()) {

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -2,6 +2,11 @@ package com.mju.capstone_backend.domain.reservation.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
+import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
+import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.entity.Reservation;
 import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
@@ -24,8 +29,11 @@ public class ReservationServiceImpl implements ReservationService {
 
     private static final Set<String> VALID_TYPES = Set.of("flight", "accommodation", "car_rental");
     private static final Set<String> VALID_STATUSES = Set.of("confirmed", "changed", "cancelled");
+    private static final Set<String> VALID_BOOKED_BY = Set.of("user", "ai");
 
     private final UserRepository userRepository;
+    private final ItineraryRepository itineraryRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final ReservationRepository reservationRepository;
     private final ObjectMapper objectMapper;
     private final Scheduler dbScheduler;
@@ -58,6 +66,58 @@ public class ReservationServiceImpl implements ReservationService {
                 .onErrorMap(
                         e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch reservations.")
+                );
+    }
+
+    @Override
+    public Mono<CreateReservationResponse> createReservation(String clerkId, CreateReservationRequest request) {
+        return Mono.fromCallable(() -> {
+            if (!userRepository.existsById(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found. Please sign up first.");
+            }
+
+            if (!VALID_TYPES.contains(request.type())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "type must be one of: flight, accommodation, car_rental.");
+            }
+
+            if (!VALID_BOOKED_BY.contains(request.bookedBy())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "bookedBy must be one of: user, ai.");
+            }
+
+            Itinerary itinerary = itineraryRepository.findById(request.itineraryId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Itinerary not found."));
+
+            var chatRoom = chatRoomRepository.findById(itinerary.getRoomId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Itinerary not found."));
+
+            if (!chatRoom.getClerkId().equals(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to create a reservation for this itinerary.");
+            }
+
+            String detailJson = objectMapper.writeValueAsString(request.detail());
+
+            Reservation reservation = Reservation.of(
+                    request.itineraryId(),
+                    request.type(),
+                    "confirmed",
+                    request.bookedBy(),
+                    request.bookingUrl(),
+                    request.externalRefId(),
+                    detailJson,
+                    request.totalPrice(),
+                    request.currency() != null ? request.currency() : "KRW",
+                    request.reservedAt()
+            );
+
+            Reservation saved = reservationRepository.save(reservation);
+            return CreateReservationResponse.from(saved);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create reservation.")
                 );
     }
 

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -8,6 +8,8 @@ import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
 import com.mju.capstone_backend.domain.reservation.entity.Reservation;
 import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
 import com.mju.capstone_backend.domain.user.repository.UserRepository;
@@ -22,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -118,6 +121,54 @@ public class ReservationServiceImpl implements ReservationService {
                 .onErrorMap(
                         e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create reservation.")
+                );
+    }
+
+    @Override
+    public Mono<PatchReservationResponse> updateReservation(String clerkId, UUID reservationId, PatchReservationRequest request) {
+        return Mono.fromCallable(() -> {
+            if (request.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one field must be provided.");
+            }
+
+            if (request.status() != null && !VALID_STATUSES.contains(request.status())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "status must be one of: confirmed, changed, cancelled.");
+            }
+
+            Reservation reservation = reservationRepository.findById(reservationId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+            Itinerary itinerary = itineraryRepository.findById(reservation.getItineraryId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+            var chatRoom = chatRoomRepository.findById(itinerary.getRoomId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+            if (!chatRoom.getClerkId().equals(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to update this reservation.");
+            }
+
+            String detailJson = request.detail() != null
+                    ? objectMapper.writeValueAsString(request.detail())
+                    : null;
+
+            reservation.update(
+                    request.status(),
+                    detailJson,
+                    request.totalPrice(),
+                    request.currency(),
+                    request.reservedAt(),
+                    request.cancelledAt()
+            );
+
+            Reservation saved = reservationRepository.save(reservation);
+            return PatchReservationResponse.from(saved);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to update reservation.")
                 );
     }
 

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -1,0 +1,71 @@
+package com.mju.capstone_backend.domain.reservation.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
+import com.mju.capstone_backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationServiceImpl implements ReservationService {
+
+    private static final Set<String> VALID_TYPES = Set.of("flight", "accommodation", "car_rental");
+    private static final Set<String> VALID_STATUSES = Set.of("confirmed", "changed", "cancelled");
+
+    private final UserRepository userRepository;
+    private final ReservationRepository reservationRepository;
+    private final ObjectMapper objectMapper;
+    private final Scheduler dbScheduler;
+
+    @Override
+    public Mono<GetReservationsResponse> getReservations(String clerkId, String type, String status) {
+        return Mono.fromCallable(() -> {
+            if (!userRepository.existsById(clerkId)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found. Please sign up first.");
+            }
+
+            if (type != null && !VALID_TYPES.contains(type)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "type must be one of: flight, accommodation, car_rental.");
+            }
+
+            if (status != null && !VALID_STATUSES.contains(status)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "status must be one of: confirmed, changed, cancelled.");
+            }
+
+            List<GetReservationsResponse.ReservationDto> dtos = reservationRepository
+                    .findByClerkIdWithFilters(clerkId, type, status)
+                    .stream()
+                    .map(r -> GetReservationsResponse.ReservationDto.from(r, parseDetail(r)))
+                    .toList();
+
+            return new GetReservationsResponse(dtos);
+        }).subscribeOn(dbScheduler)
+                .onErrorMap(
+                        e -> !(e instanceof ResponseStatusException),
+                        e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch reservations.")
+                );
+    }
+
+    private Map<String, Object> parseDetail(Reservation reservation) {
+        try {
+            return objectMapper.readValue(reservation.getDetail(), new TypeReference<>() {});
+        } catch (Exception e) {
+            return new LinkedHashMap<>();
+        }
+    }
+}

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -100,6 +100,8 @@ public class ReservationServiceImpl implements ReservationService {
                         "You do not have permission to create a reservation for this itinerary.");
             }
 
+            validateDetail(request.type(), request.detail());
+
             String detailJson = objectMapper.writeValueAsString(request.detail());
 
             Reservation reservation = Reservation.of(
@@ -150,6 +152,10 @@ public class ReservationServiceImpl implements ReservationService {
                         "You do not have permission to update this reservation.");
             }
 
+            if (request.detail() != null) {
+                validateDetail(reservation.getType(), request.detail());
+            }
+
             String detailJson = request.detail() != null
                     ? objectMapper.writeValueAsString(request.detail())
                     : null;
@@ -196,6 +202,65 @@ public class ReservationServiceImpl implements ReservationService {
                         e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete reservation.")
                 ).then();
+    }
+
+    private void validateDetail(String type, Map<String, Object> detail) {
+        switch (type) {
+            case "flight" -> {
+                requireKeys(detail, "flight", "airline", "flight_no", "departure", "arrival", "seat_class", "passengers");
+                requireNestedKeys(detail, "flight", "departure", "airport", "datetime");
+                requireNestedKeys(detail, "flight", "arrival", "airport", "datetime");
+                requirePassengers(detail);
+            }
+            case "accommodation" -> requireKeys(detail, "accommodation", "hotel_name", "room_type", "check_in", "check_out", "guests");
+            case "car_rental" -> {
+                requireKeys(detail, "car_rental", "company", "car_model", "pickup", "dropoff");
+                requireNestedKeys(detail, "car_rental", "pickup", "location", "datetime");
+                requireNestedKeys(detail, "car_rental", "dropoff", "location", "datetime");
+            }
+        }
+    }
+
+    private void requireKeys(Map<String, Object> detail, String type, String... keys) {
+        for (String key : keys) {
+            if (!detail.containsKey(key) || detail.get(key) == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "detail." + key + " is required for type '" + type + "'.");
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void requireNestedKeys(Map<String, Object> detail, String type, String parent, String... keys) {
+        Object parentVal = detail.get(parent);
+        if (!(parentVal instanceof Map)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "detail." + parent + " must be an object for type '" + type + "'.");
+        }
+        Map<String, Object> nested = (Map<String, Object>) parentVal;
+        for (String key : keys) {
+            if (!nested.containsKey(key) || nested.get(key) == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "detail." + parent + "." + key + " is required for type '" + type + "'.");
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void requirePassengers(Map<String, Object> detail) {
+        Object val = detail.get("passengers");
+        if (!(val instanceof List<?> list) || list.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "detail.passengers must be a non-empty array for type 'flight'.");
+        }
+        for (int i = 0; i < list.size(); i++) {
+            if (!(list.get(i) instanceof Map<?, ?> passenger)
+                    || !passenger.containsKey("name") || passenger.get("name") == null
+                    || !passenger.containsKey("passport") || passenger.get("passport") == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "detail.passengers[" + i + "] must include name and passport.");
+            }
+        }
     }
 
     private Map<String, Object> parseDetail(Reservation reservation) {

--- a/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImpl.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
 import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
 import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.reservation.dto.CancelReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.ChangeReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.DeleteReservationResponse;
@@ -129,14 +131,14 @@ public class ReservationServiceImpl implements ReservationService {
 
     @Override
     public Mono<PatchReservationResponse> updateReservation(String clerkId, UUID reservationId, PatchReservationRequest request) {
-        return Mono.fromCallable(() -> {
+        return Mono.<PatchReservationResponse>fromCallable(() -> {
             if (request.isEmpty()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one field must be provided.");
             }
 
             if (request.status() != null && !VALID_STATUSES.contains(request.status())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                        "status must be one of: confirmed, changed, cancelled.");
+                        "status must be one of: changed, cancelled.");
             }
 
             Reservation reservation = reservationRepository.findById(reservationId)
@@ -151,6 +153,22 @@ public class ReservationServiceImpl implements ReservationService {
             if (!chatRoom.getClerkId().equals(clerkId)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                         "You do not have permission to update this reservation.");
+            }
+
+            if ("cancelled".equals(reservation.getStatus())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Cannot update a reservation that has already been cancelled.");
+            }
+
+            if ("cancelled".equals(request.status()) && request.cancelledAt() == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "cancelledAt is required when status is cancelled.");
+            }
+
+            if ("changed".equals(request.status())
+                    && (request.detail() == null || request.reservedAt() == null)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "detail, reservedAt are required when status is changed.");
             }
 
             if (request.detail() != null) {
@@ -171,7 +189,9 @@ public class ReservationServiceImpl implements ReservationService {
             );
 
             Reservation saved = reservationRepository.save(reservation);
-            return PatchReservationResponse.from(saved);
+            return "cancelled".equals(request.status())
+                    ? CancelReservationResponse.from(saved)
+                    : ChangeReservationResponse.from(saved);
         }).subscribeOn(dbScheduler)
                 .onErrorMap(
                         e -> !(e instanceof ResponseStatusException),
@@ -224,7 +244,8 @@ public class ReservationServiceImpl implements ReservationService {
 
     private void requireKeys(Map<String, Object> detail, String type, String... keys) {
         for (String key : keys) {
-            if (!detail.containsKey(key) || detail.get(key) == null) {
+            Object val = detail.get(key);
+            if (!detail.containsKey(key) || val == null || (val instanceof String s && s.isBlank())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "detail." + key + " is required for type '" + type + "'.");
             }
@@ -240,7 +261,8 @@ public class ReservationServiceImpl implements ReservationService {
         }
         Map<String, Object> nested = (Map<String, Object>) parentVal;
         for (String key : keys) {
-            if (!nested.containsKey(key) || nested.get(key) == null) {
+            Object val = nested.get(key);
+            if (!nested.containsKey(key) || val == null || (val instanceof String s && s.isBlank())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "detail." + parent + "." + key + " is required for type '" + type + "'.");
             }
@@ -255,12 +277,16 @@ public class ReservationServiceImpl implements ReservationService {
         }
         for (int i = 0; i < list.size(); i++) {
             if (!(list.get(i) instanceof Map<?, ?> passenger)
-                    || !passenger.containsKey("name") || passenger.get("name") == null
-                    || !passenger.containsKey("passport") || passenger.get("passport") == null) {
+                    || isBlankValue(passenger.get("name"))
+                    || isBlankValue(passenger.get("passport"))) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "detail.passengers[" + i + "] must include name and passport.");
             }
         }
+    }
+
+    private boolean isBlankValue(Object val) {
+        return val == null || (val instanceof String s && s.isBlank());
     }
 
     private Map<String, Object> parseDetail(Reservation reservation) {

--- a/src/main/java/com/mju/capstone_backend/global/dev/DevReservationController.java
+++ b/src/main/java/com/mju/capstone_backend/global/dev/DevReservationController.java
@@ -1,0 +1,115 @@
+package com.mju.capstone_backend.global.dev;
+
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 개발용 예약 데이터 시드 엔드포인트.
+ *
+ * GET /api/v1/reservations 테스트를 위해 항공·숙소·렌트카 샘플 예약 3건을 생성한다.
+ * itineraryId는 기존 일정의 UUID를 사용한다 (chat-rooms → itinerary 생성 후 획득).
+ *
+ * Swagger 사용법:
+ * 1. POST /dev/reservations/seed — itineraryId 전달 → 샘플 예약 3건 생성
+ * 2. GET /api/v1/reservations — dev-{clerkId} 토큰으로 조회 확인
+ * 3. DELETE /dev/reservations/seed/{itineraryId} — 시드 데이터 정리
+ *
+ * @Profile("dev") — 운영 환경에서는 빈 자체가 등록되지 않음.
+ */
+@Tag(name = "[DEV] Reservation API")
+@RestController
+@RequestMapping("/dev/reservations")
+@Profile("dev")
+@RequiredArgsConstructor
+public class DevReservationController {
+
+        private static final String FLIGHT_DETAIL = """
+                        {
+                          "airline": "대한항공",
+                          "flight_no": "KE123",
+                          "departure": {"airport": "ICN", "datetime": "2026-05-01T09:00:00"},
+                          "arrival":   {"airport": "NRT", "datetime": "2026-05-01T11:30:00"},
+                          "seat_class": "economy",
+                          "passengers": [{"name": "홍길동", "passport": "M12345678"}]
+                        }
+                        """;
+
+        private static final String ACCOMMODATION_DETAIL = """
+                        {
+                          "hotel_name": "롯데호텔 도쿄",
+                          "room_type": "디럭스 더블",
+                          "check_in": "2026-05-01",
+                          "check_out": "2026-05-03",
+                          "guests": 2
+                        }
+                        """;
+
+        private static final String CAR_RENTAL_DETAIL = """
+                        {
+                          "company": "Hertz",
+                          "car_model": "Toyota Camry",
+                          "pickup":  {"location": "NRT T1", "datetime": "2026-05-01T13:00:00"},
+                          "dropoff": {"location": "NRT T1", "datetime": "2026-05-03T11:00:00"}
+                        }
+                        """;
+
+        @Schema(example = """
+                        {
+                          "itineraryId": "550e8400-e29b-41d4-a716-446655440000"
+                        }
+                        """)
+        record SeedRequest(UUID itineraryId) {
+        }
+
+        private final ReservationRepository reservationRepository;
+        private final Scheduler dbScheduler;
+
+        @Operation(summary = "[DEV] 테스트 예약 데이터 생성", description = "itineraryId에 항공·숙소·렌트카 샘플 예약 3건을 생성하고 생성된 ID 목록을 반환합니다.")
+        @PostMapping("/seed")
+        @ResponseStatus(HttpStatus.CREATED)
+        public Mono<Map<String, Object>> seed(@RequestBody SeedRequest request) {
+                return Mono.fromCallable(() -> {
+                        OffsetDateTime now = OffsetDateTime.now();
+                        List<Reservation> samples = List.of(
+                                        Reservation.of(request.itineraryId(), "flight", "confirmed", "ai",
+                                                        null, "KE-20260501-001", FLIGHT_DETAIL,
+                                                        new BigDecimal("350000"), "KRW", now),
+                                        Reservation.of(request.itineraryId(), "accommodation", "confirmed", "user",
+                                                        null, "LOTTE-20260501", ACCOMMODATION_DETAIL,
+                                                        new BigDecimal("180000"), "KRW", now),
+                                        Reservation.of(request.itineraryId(), "car_rental", "confirmed", "ai",
+                                                        null, "HERTZ-20260501", CAR_RENTAL_DETAIL,
+                                                        new BigDecimal("95000"), "KRW", now));
+                        List<UUID> ids = reservationRepository.saveAll(samples)
+                                        .stream()
+                                        .map(Reservation::getId)
+                                        .toList();
+                        return Map.of("itineraryId", request.itineraryId(), "reservationIds", ids);
+                }).subscribeOn(dbScheduler);
+        }
+
+        @Operation(summary = "[DEV] 테스트 예약 데이터 삭제", description = "itineraryId에 연결된 모든 예약을 삭제합니다.")
+        @DeleteMapping("/seed/{itineraryId}")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        public Mono<Void> deleteSeed(@PathVariable UUID itineraryId) {
+                return Mono.fromCallable(() -> {
+                        reservationRepository.deleteAllByItineraryId(itineraryId);
+                        return null;
+                }).subscribeOn(dbScheduler).then();
+        }
+}

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -5,7 +5,7 @@ import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse
 import com.mju.capstone_backend.domain.reservation.dto.DeleteReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
-import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.CancelReservationResponse;
 import com.mju.capstone_backend.domain.reservation.service.ReservationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -295,8 +295,8 @@ class ReservationControllerTest {
     @Test
     @DisplayName("예약 수정 - 유효한 JWT + 정상 body - 200 반환 및 응답 확인")
     void updateReservation_withValidJwt_returns200() {
-        PatchReservationResponse response = new PatchReservationResponse(
-                RESERVATION_ID, "cancelled", OffsetDateTime.now()
+        CancelReservationResponse response = new CancelReservationResponse(
+                RESERVATION_ID, "cancelled", OffsetDateTime.now(), OffsetDateTime.now()
         );
         when(reservationService.updateReservation(eq(CLERK_ID), eq(RESERVATION_ID), any(PatchReservationRequest.class)))
                 .thenReturn(Mono.just(response));

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -3,6 +3,8 @@ package com.mju.capstone_backend.domain.reservation.controller;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
 import com.mju.capstone_backend.domain.reservation.service.ReservationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -284,6 +286,99 @@ class ReservationControllerTest {
                 .bodyValue(buildRequestBody())
                 .exchange()
                 .expectStatus().isForbidden();
+    }
+
+    // ─── PATCH /api/v1/reservations/{reservationId} ───────────────────────────
+
+    @Test
+    @DisplayName("예약 수정 - 유효한 JWT + 정상 body - 200 반환 및 응답 확인")
+    void updateReservation_withValidJwt_returns200() {
+        PatchReservationResponse response = new PatchReservationResponse(
+                RESERVATION_ID, "cancelled", OffsetDateTime.now()
+        );
+        when(reservationService.updateReservation(eq(CLERK_ID), eq(RESERVATION_ID), any(PatchReservationRequest.class)))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .patch()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("status", "cancelled", "cancelledAt", "2026-04-10T10:00:00+09:00"))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.reservationId").isEqualTo(RESERVATION_ID.toString())
+                .jsonPath("$.status").isEqualTo("cancelled");
+
+        verify(reservationService).updateReservation(eq(CLERK_ID), eq(RESERVATION_ID), any(PatchReservationRequest.class));
+    }
+
+    @Test
+    @DisplayName("예약 수정 - JWT 없이 요청 시 401 반환")
+    void updateReservation_withoutJwt_returns401() {
+        webTestClient
+                .patch()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("status", "cancelled"))
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("예약 수정 - 존재하지 않는 예약 - 404 반환")
+    void updateReservation_reservationNotFound_returns404() {
+        when(reservationService.updateReservation(eq(CLERK_ID), eq(RESERVATION_ID), any(PatchReservationRequest.class)))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Reservation not found.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .patch()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("status", "cancelled"))
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    @Test
+    @DisplayName("예약 수정 - 다른 사용자의 예약 - 403 반환")
+    void updateReservation_notOwner_returns403() {
+        when(reservationService.updateReservation(eq(CLERK_ID), eq(RESERVATION_ID), any(PatchReservationRequest.class)))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to update this reservation.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .patch()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("status", "cancelled"))
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    @Test
+    @DisplayName("예약 수정 - 빈 body - 400 반환")
+    void updateReservation_emptyBody_returns400() {
+        when(reservationService.updateReservation(eq(CLERK_ID), eq(RESERVATION_ID), any(PatchReservationRequest.class)))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "At least one field must be provided.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .patch()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of())
+                .exchange()
+                .expectStatus().isBadRequest();
     }
 
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -197,7 +197,8 @@ class ReservationControllerTest {
     @DisplayName("예약 생성 - 유효한 JWT + 정상 body - 201 반환 및 응답 확인")
     void createReservation_withValidJwt_returns201() {
         CreateReservationResponse response = new CreateReservationResponse(
-                RESERVATION_ID, ITINERARY_ID, "flight", "confirmed", OffsetDateTime.now()
+                RESERVATION_ID, ITINERARY_ID, "flight", "confirmed",
+                OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now()
         );
         when(reservationService.createReservation(eq(CLERK_ID), any(CreateReservationRequest.class)))
                 .thenReturn(Mono.just(response));

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -1,5 +1,7 @@
 package com.mju.capstone_backend.domain.reservation.controller;
 
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.service.ReservationService;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -184,5 +187,124 @@ class ReservationControllerTest {
                 .uri("/api/v1/reservations")
                 .exchange()
                 .expectStatus().isNotFound();
+    }
+
+    // ─── POST /api/v1/reservations ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 생성 - 유효한 JWT + 정상 body - 201 반환 및 응답 확인")
+    void createReservation_withValidJwt_returns201() {
+        CreateReservationResponse response = new CreateReservationResponse(
+                RESERVATION_ID, ITINERARY_ID, "flight", "confirmed", OffsetDateTime.now()
+        );
+        when(reservationService.createReservation(eq(CLERK_ID), any(CreateReservationRequest.class)))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .post()
+                .uri("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(buildRequestBody())
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody()
+                .jsonPath("$.reservationId").isEqualTo(RESERVATION_ID.toString())
+                .jsonPath("$.itineraryId").isEqualTo(ITINERARY_ID.toString())
+                .jsonPath("$.type").isEqualTo("flight")
+                .jsonPath("$.status").isEqualTo("confirmed");
+
+        verify(reservationService).createReservation(eq(CLERK_ID), any(CreateReservationRequest.class));
+    }
+
+    @Test
+    @DisplayName("예약 생성 - JWT 없이 요청 시 401 반환")
+    void createReservation_withoutJwt_returns401() {
+        webTestClient
+                .post()
+                .uri("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(buildRequestBody())
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("예약 생성 - itineraryId 누락 시 400 반환")
+    void createReservation_missingItineraryId_returns400() {
+        Map<String, Object> body = Map.of(
+                "type", "flight",
+                "bookedBy", "ai",
+                "detail", Map.of("airline", "대한항공")
+        );
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .post()
+                .uri("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("예약 생성 - 존재하지 않는 itinerary - 404 반환")
+    void createReservation_itineraryNotFound_returns404() {
+        when(reservationService.createReservation(eq(CLERK_ID), any(CreateReservationRequest.class)))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Itinerary not found.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .post()
+                .uri("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(buildRequestBody())
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    @Test
+    @DisplayName("예약 생성 - 다른 사용자의 itinerary - 403 반환")
+    void createReservation_notOwner_returns403() {
+        when(reservationService.createReservation(eq(CLERK_ID), any(CreateReservationRequest.class)))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to create a reservation for this itinerary.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .post()
+                .uri("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(buildRequestBody())
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    // ─── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    private Map<String, Object> buildRequestBody() {
+        return Map.of(
+                "itineraryId", ITINERARY_ID.toString(),
+                "type", "flight",
+                "bookedBy", "ai",
+                "bookingUrl", "https://booking.example.com/flight/123",
+                "externalRefId", "KE12345678",
+                "detail", Map.of(
+                        "airline", "대한항공",
+                        "flight_no", "KE123",
+                        "departure", Map.of("airport", "ICN", "datetime", "2026-05-01T09:00:00"),
+                        "arrival", Map.of("airport", "NRT", "datetime", "2026-05-01T11:30:00"),
+                        "seat_class", "economy",
+                        "passengers", List.of(Map.of("name", "홍길동", "passport", "M12345678"))
+                ),
+                "totalPrice", 320000.00,
+                "currency", "KRW"
+        );
     }
 }

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -1,0 +1,188 @@
+package com.mju.capstone_backend.domain.reservation.controller;
+
+import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
+import com.mju.capstone_backend.domain.reservation.service.ReservationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+@TestPropertySource(locations = "file:.env")
+@DisplayName("ReservationController 슬라이스 테스트")
+class ReservationControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private ReservationService reservationService;
+
+    private static final String CLERK_ID = "user_testClerkId";
+    private static final UUID RESERVATION_ID = UUID.randomUUID();
+    private static final UUID ITINERARY_ID = UUID.randomUUID();
+
+    // ─── GET /api/v1/reservations ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 목록 조회 - 유효한 JWT로 200 반환 및 응답 데이터 확인")
+    void getReservations_withValidJwt_returns200() {
+        GetReservationsResponse response = new GetReservationsResponse(List.of(
+                new GetReservationsResponse.ReservationDto(
+                        RESERVATION_ID, ITINERARY_ID, "flight", "confirmed", "ai",
+                        null, "KE-20260501-001", Map.of(), new BigDecimal("350000"), "KRW",
+                        OffsetDateTime.now(), null, OffsetDateTime.now(), OffsetDateTime.now()
+                )
+        ));
+        when(reservationService.getReservations(CLERK_ID, null, null))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/reservations")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.reservations").isArray()
+                .jsonPath("$.reservations[0].reservationId").isEqualTo(RESERVATION_ID.toString())
+                .jsonPath("$.reservations[0].itineraryId").isEqualTo(ITINERARY_ID.toString())
+                .jsonPath("$.reservations[0].type").isEqualTo("flight")
+                .jsonPath("$.reservations[0].status").isEqualTo("confirmed");
+
+        verify(reservationService).getReservations(CLERK_ID, null, null);
+    }
+
+    @Test
+    @DisplayName("예약 목록 조회 - JWT 없이 요청 시 401 반환")
+    void getReservations_withoutJwt_returns401() {
+        webTestClient
+                .get()
+                .uri("/api/v1/reservations")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("예약 목록 조회 - type 필터 적용 시 서비스에 전달 및 응답 확인")
+    void getReservations_withTypeFilter_passedToService() {
+        GetReservationsResponse response = new GetReservationsResponse(List.of(
+                new GetReservationsResponse.ReservationDto(
+                        RESERVATION_ID, ITINERARY_ID, "flight", "confirmed", "ai",
+                        null, "KE-20260501-001", Map.of(), new BigDecimal("350000"), "KRW",
+                        OffsetDateTime.now(), null, OffsetDateTime.now(), OffsetDateTime.now()
+                )
+        ));
+        when(reservationService.getReservations(CLERK_ID, "flight", null))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/reservations?type=flight")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.reservations[0].type").isEqualTo("flight");
+
+        verify(reservationService).getReservations(CLERK_ID, "flight", null);
+    }
+
+    @Test
+    @DisplayName("예약 목록 조회 - status 필터 적용 시 서비스에 전달 및 응답 확인")
+    void getReservations_withStatusFilter_passedToService() {
+        GetReservationsResponse response = new GetReservationsResponse(List.of(
+                new GetReservationsResponse.ReservationDto(
+                        RESERVATION_ID, ITINERARY_ID, "accommodation", "confirmed", "user",
+                        null, "LOTTE-20260501", Map.of(), new BigDecimal("180000"), "KRW",
+                        OffsetDateTime.now(), null, OffsetDateTime.now(), OffsetDateTime.now()
+                )
+        ));
+        when(reservationService.getReservations(CLERK_ID, null, "confirmed"))
+                .thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/reservations?status=confirmed")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.reservations[0].status").isEqualTo("confirmed");
+
+        verify(reservationService).getReservations(CLERK_ID, null, "confirmed");
+    }
+
+    @Test
+    @DisplayName("예약 목록 조회 - 잘못된 type 파라미터 시 400 반환")
+    void getReservations_withInvalidType_returns400() {
+        when(reservationService.getReservations(eq(CLERK_ID), eq("invalid"), any()))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "type must be one of: flight, accommodation, car_rental.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/reservations?type=invalid")
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("예약 목록 조회 - 잘못된 status 파라미터 시 400 반환")
+    void getReservations_withInvalidStatus_returns400() {
+        when(reservationService.getReservations(eq(CLERK_ID), any(), eq("invalid")))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "status must be one of: confirmed, changed, cancelled.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/reservations?status=invalid")
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("예약 목록 조회 - 존재하지 않는 사용자 시 404 반환")
+    void getReservations_userNotFound_returns404() {
+        when(reservationService.getReservations(CLERK_ID, null, null))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "User not found. Please sign up first.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .get()
+                .uri("/api/v1/reservations")
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+}

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -381,6 +381,67 @@ class ReservationControllerTest {
                 .expectStatus().isBadRequest();
     }
 
+    // ─── DELETE /api/v1/reservations/{reservationId} ─────────────────────────
+
+    @Test
+    @DisplayName("예약 삭제 - 유효한 JWT - 204 반환")
+    void deleteReservation_withValidJwt_returns204() {
+        when(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                .thenReturn(Mono.empty());
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .delete()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        verify(reservationService).deleteReservation(CLERK_ID, RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("예약 삭제 - JWT 없이 요청 시 401 반환")
+    void deleteReservation_withoutJwt_returns401() {
+        webTestClient
+                .delete()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("예약 삭제 - 존재하지 않는 예약 - 404 반환")
+    void deleteReservation_reservationNotFound_returns404() {
+        when(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Reservation not found.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .delete()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    @Test
+    @DisplayName("예약 삭제 - 다른 사용자의 예약 - 403 반환")
+    void deleteReservation_notOwner_returns403() {
+        when(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to delete this reservation.")));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.subject(CLERK_ID)))
+                .delete()
+                .uri("/api/v1/reservations/" + RESERVATION_ID)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────
 
     private Map<String, Object> buildRequestBody() {

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/controller/ReservationControllerTest.java
@@ -2,6 +2,7 @@ package com.mju.capstone_backend.domain.reservation.controller;
 
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.DeleteReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.GetReservationsResponse;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationResponse;
@@ -385,10 +386,10 @@ class ReservationControllerTest {
     // ─── DELETE /api/v1/reservations/{reservationId} ─────────────────────────
 
     @Test
-    @DisplayName("예약 삭제 - 유효한 JWT - 204 반환")
-    void deleteReservation_withValidJwt_returns204() {
+    @DisplayName("예약 삭제 - 유효한 JWT - 200 반환 및 응답 확인")
+    void deleteReservation_withValidJwt_returns200() {
         when(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
-                .thenReturn(Mono.empty());
+                .thenReturn(Mono.just(new DeleteReservationResponse(RESERVATION_ID, true)));
 
         webTestClient
                 .mutateWith(SecurityMockServerConfigurers.mockJwt()
@@ -396,7 +397,10 @@ class ReservationControllerTest {
                 .delete()
                 .uri("/api/v1/reservations/" + RESERVATION_ID)
                 .exchange()
-                .expectStatus().isNoContent();
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.reservationId").isEqualTo(RESERVATION_ID.toString())
+                .jsonPath("$.deleted").isEqualTo(true);
 
         verify(reservationService).deleteReservation(CLERK_ID, RESERVATION_ID);
     }

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -38,420 +38,552 @@ import static org.mockito.Mockito.*;
 @DisplayName("ReservationServiceImpl 단위 테스트")
 class ReservationServiceImplTest {
 
-    @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private ItineraryRepository itineraryRepository;
-
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
-
-    @Mock
-    private ReservationRepository reservationRepository;
-
-    @Mock
-    private ObjectMapper objectMapper;
-
-    @InjectMocks
-    private ReservationServiceImpl reservationService;
-
-    private static final String CLERK_ID = "user_testClerkId";
-    private static final UUID RESERVATION_ID = UUID.randomUUID();
-    private static final UUID ITINERARY_ID = UUID.randomUUID();
-    private static final UUID ROOM_ID = UUID.randomUUID();
-
-    @BeforeEach
-    void injectScheduler() throws Exception {
-        var field = ReservationServiceImpl.class.getDeclaredField("dbScheduler");
-        field.setAccessible(true);
-        field.set(reservationService, Schedulers.immediate());
-    }
-
-    // ─── 사용자 검증 ──────────────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("존재하지 않는 사용자 - 404 예외")
-    void getReservations_userNotFound_throws404() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(false);
-
-        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.NOT_FOUND)
-                .verify();
-
-        verify(reservationRepository, never()).findByClerkIdWithFilters(any(), any(), any());
-    }
-
-    // ─── 파라미터 검증 ────────────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("잘못된 type 파라미터 - 400 예외")
-    void getReservations_invalidType_throws400() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-
-        StepVerifier.create(reservationService.getReservations(CLERK_ID, "invalid", null))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
-                .verify();
-    }
-
-    @Test
-    @DisplayName("잘못된 status 파라미터 - 400 예외")
-    void getReservations_invalidStatus_throws400() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-
-        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, "invalid"))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
-                .verify();
-    }
-
-    // ─── 정상 조회 ────────────────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("필터 없이 조회 - 전체 예약 목록 반환")
-    void getReservations_noFilters_returnsAll() throws Exception {
-        Reservation mockReservation = buildMockReservation("flight", "confirmed");
-
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, null, null))
-                .thenReturn(List.of(mockReservation));
-        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
-                .thenReturn(Map.of());
-
-        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
-                .assertNext(response -> {
-                    assertThat(response.reservations()).hasSize(1);
-                    assertThat(response.reservations().get(0).type()).isEqualTo("flight");
-                    assertThat(response.reservations().get(0).status()).isEqualTo("confirmed");
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    @DisplayName("type 필터 적용 - 리포지토리에 type 전달")
-    void getReservations_withTypeFilter_passedToRepository() throws Exception {
-        Reservation mockReservation = buildMockReservation("accommodation", "confirmed");
-
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, "accommodation", null))
-                .thenReturn(List.of(mockReservation));
-        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
-                .thenReturn(Map.of());
-
-        StepVerifier.create(reservationService.getReservations(CLERK_ID, "accommodation", null))
-                .assertNext(response -> assertThat(response.reservations()).hasSize(1))
-                .verifyComplete();
-
-        verify(reservationRepository).findByClerkIdWithFilters(CLERK_ID, "accommodation", null);
-    }
-
-    @Test
-    @DisplayName("결과 없음 - 빈 목록 반환")
-    void getReservations_noResults_returnsEmptyList() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, null, null))
-                .thenReturn(List.of());
-
-        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
-                .assertNext(response -> assertThat(response.reservations()).isEmpty())
-                .verifyComplete();
-    }
-
-    // ─── createReservation: 사용자/파라미터 검증 ──────────────────────────────
-
-    @Test
-    @DisplayName("예약 생성 - 존재하지 않는 사용자 - 404 예외")
-    void createReservation_userNotFound_throws404() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(false);
-
-        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.NOT_FOUND)
-                .verify();
-
-        verify(itineraryRepository, never()).findById(any());
-    }
-
-    @Test
-    @DisplayName("예약 생성 - 잘못된 type - 400 예외")
-    void createReservation_invalidType_throws400() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-
-        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("train", "ai")))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
-                        && rse.getReason().equals("type must be one of: flight, accommodation, car_rental."))
-                .verify();
-    }
-
-    @Test
-    @DisplayName("예약 생성 - 잘못된 bookedBy - 400 예외")
-    void createReservation_invalidBookedBy_throws400() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-
-        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "bot")))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
-                        && rse.getReason().equals("bookedBy must be one of: user, ai."))
-                .verify();
-    }
-
-    // ─── createReservation: 소유권 검증 ──────────────────────────────────────
-
-    @Test
-    @DisplayName("예약 생성 - 존재하지 않는 itinerary - 404 예외")
-    void createReservation_itineraryNotFound_throws404() {
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.empty());
-
-        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.NOT_FOUND
-                        && rse.getReason().equals("Itinerary not found."))
-                .verify();
-    }
-
-    @Test
-    @DisplayName("예약 생성 - 다른 사용자의 itinerary - 403 예외")
-    void createReservation_notOwner_throws403() {
-        Itinerary mockItinerary = mock(Itinerary.class);
-        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
-        ChatRoom otherChatRoom = mock(ChatRoom.class);
-        when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
-
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
-        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
-
-        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.FORBIDDEN)
-                .verify();
-    }
-
-    // ─── createReservation: 정상 생성 ────────────────────────────────────────
-
-    @Test
-    @DisplayName("예약 생성 - 정상 요청 - 생성된 예약 반환")
-    void createReservation_success_returnsResponse() throws Exception {
-        Itinerary mockItinerary = mock(Itinerary.class);
-        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
-        ChatRoom mockChatRoom = mock(ChatRoom.class);
-        when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
-        Reservation mockReservation = mock(Reservation.class);
-        when(mockReservation.getId()).thenReturn(UUID.randomUUID());
-        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
-        when(mockReservation.getType()).thenReturn("flight");
-        when(mockReservation.getStatus()).thenReturn("confirmed");
-        when(mockReservation.getCreatedAt()).thenReturn(OffsetDateTime.now());
-
-        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
-        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
-        when(objectMapper.writeValueAsString(any())).thenReturn("{\"airline\":\"대한항공\"}");
-        when(reservationRepository.save(any())).thenReturn(mockReservation);
-
-        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
-                .assertNext(response -> {
-                    assertThat(response.reservationId()).isNotNull();
-                    assertThat(response.type()).isEqualTo("flight");
-                    assertThat(response.status()).isEqualTo("confirmed");
-                })
-                .verifyComplete();
-
-        verify(reservationRepository).save(any());
-    }
-
-    // ─── updateReservation: 파라미터 검증 ────────────────────────────────────
-
-    @Test
-    @DisplayName("예약 수정 - 빈 body - 400 예외")
-    void updateReservation_emptyBody_throws400() {
-        PatchReservationRequest emptyRequest = new PatchReservationRequest(null, null, null, null, null, null);
-
-        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, emptyRequest))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
-                        && rse.getReason().equals("At least one field must be provided."))
-                .verify();
-    }
-
-    @Test
-    @DisplayName("예약 수정 - 잘못된 status - 400 예외")
-    void updateReservation_invalidStatus_throws400() {
-        PatchReservationRequest request = new PatchReservationRequest("invalid", null, null, null, null, null);
-
-        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
-                        && rse.getReason().equals("status must be one of: confirmed, changed, cancelled."))
-                .verify();
-    }
-
-    // ─── updateReservation: 소유권 검증 ──────────────────────────────────────
-
-    @Test
-    @DisplayName("예약 수정 - 존재하지 않는 예약 - 404 예외")
-    void updateReservation_reservationNotFound_throws404() {
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
-
-        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
-                        new PatchReservationRequest("cancelled", null, null, null, null, null)))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.NOT_FOUND
-                        && rse.getReason().equals("Reservation not found."))
-                .verify();
-    }
-
-    @Test
-    @DisplayName("예약 수정 - 다른 사용자의 예약 - 403 예외")
-    void updateReservation_notOwner_throws403() {
-        Reservation mockReservation = mock(Reservation.class);
-        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
-        Itinerary mockItinerary = mock(Itinerary.class);
-        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
-        ChatRoom otherChatRoom = mock(ChatRoom.class);
-        when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
-
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
-        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
-
-        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
-                        new PatchReservationRequest("cancelled", null, null, null, null, null)))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.FORBIDDEN)
-                .verify();
-    }
-
-    // ─── updateReservation: 정상 수정 ────────────────────────────────────────
-
-    @Test
-    @DisplayName("예약 수정 - 상태 변경 - 수정된 예약 반환")
-    void updateReservation_statusChange_returnsResponse() {
-        Reservation mockReservation = mock(Reservation.class);
-        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
-        when(mockReservation.getId()).thenReturn(RESERVATION_ID);
-        when(mockReservation.getStatus()).thenReturn("cancelled");
-        when(mockReservation.getUpdatedAt()).thenReturn(OffsetDateTime.now());
-        Itinerary mockItinerary = mock(Itinerary.class);
-        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
-        ChatRoom mockChatRoom = mock(ChatRoom.class);
-        when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
-
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
-        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
-        when(reservationRepository.save(any())).thenReturn(mockReservation);
-
-        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
-                        new PatchReservationRequest("cancelled", null, null, null, null, OffsetDateTime.now())))
-                .assertNext(response -> {
-                    assertThat(response.reservationId()).isEqualTo(RESERVATION_ID);
-                    assertThat(response.status()).isEqualTo("cancelled");
-                    assertThat(response.updatedAt()).isNotNull();
-                })
-                .verifyComplete();
-
-        verify(reservationRepository).save(mockReservation);
-    }
-
-    // ─── deleteReservation ────────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("예약 삭제 - 존재하지 않는 예약 - 404 예외")
-    void deleteReservation_reservationNotFound_throws404() {
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
-
-        StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.NOT_FOUND
-                        && rse.getReason().equals("Reservation not found."))
-                .verify();
-    }
-
-    @Test
-    @DisplayName("예약 삭제 - 다른 사용자의 예약 - 403 예외")
-    void deleteReservation_notOwner_throws403() {
-        Reservation mockReservation = mock(Reservation.class);
-        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
-        Itinerary mockItinerary = mock(Itinerary.class);
-        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
-        ChatRoom otherChatRoom = mock(ChatRoom.class);
-        when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
-
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
-        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
-
-        StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == HttpStatus.FORBIDDEN)
-                .verify();
-
-        verify(reservationRepository, never()).delete(any());
-    }
-
-    @Test
-    @DisplayName("예약 삭제 - 정상 요청 - delete 호출 후 완료")
-    void deleteReservation_success_completesAndCallsDelete() {
-        Reservation mockReservation = mock(Reservation.class);
-        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
-        Itinerary mockItinerary = mock(Itinerary.class);
-        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
-        ChatRoom mockChatRoom = mock(ChatRoom.class);
-        when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
-
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
-        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
-        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
-
-        StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
-                .verifyComplete();
-
-        verify(reservationRepository).delete(mockReservation);
-    }
-
-    // ─── 헬퍼 ────────────────────────────────────────────────────────────────
-
-    private CreateReservationRequest buildCreateRequest(String type, String bookedBy) {
-        return new CreateReservationRequest(
-                ITINERARY_ID,
-                type,
-                bookedBy,
-                "https://booking.example.com/flight/123",
-                "KE12345678",
-                Map.of("airline", "대한항공", "flight_no", "KE123"),
-                new BigDecimal("320000"),
-                "KRW",
-                OffsetDateTime.now()
-        );
-    }
-
-    private Itinerary buildMockItinerary() {
-        Itinerary itinerary = mock(Itinerary.class);
-        when(itinerary.getRoomId()).thenReturn(ROOM_ID);
-        return itinerary;
-    }
-
-    private Reservation buildMockReservation(String type, String status) {
-        Reservation r = mock(Reservation.class);
-        when(r.getId()).thenReturn(UUID.randomUUID());
-        when(r.getItineraryId()).thenReturn(UUID.randomUUID());
-        when(r.getType()).thenReturn(type);
-        when(r.getStatus()).thenReturn(status);
-        when(r.getBookedBy()).thenReturn("ai");
-        when(r.getBookingUrl()).thenReturn(null);
-        when(r.getExternalRefId()).thenReturn("REF-001");
-        when(r.getDetail()).thenReturn("{}");
-        when(r.getTotalPrice()).thenReturn(BigDecimal.valueOf(350000));
-        when(r.getCurrency()).thenReturn("KRW");
-        when(r.getReservedAt()).thenReturn(OffsetDateTime.now());
-        when(r.getCancelledAt()).thenReturn(null);
-        when(r.getCreatedAt()).thenReturn(OffsetDateTime.now());
-        when(r.getUpdatedAt()).thenReturn(OffsetDateTime.now());
-        return r;
-    }
+        @Mock
+        private UserRepository userRepository;
+
+        @Mock
+        private ItineraryRepository itineraryRepository;
+
+        @Mock
+        private ChatRoomRepository chatRoomRepository;
+
+        @Mock
+        private ReservationRepository reservationRepository;
+
+        @Mock
+        private ObjectMapper objectMapper;
+
+        @InjectMocks
+        private ReservationServiceImpl reservationService;
+
+        private static final String CLERK_ID = "user_testClerkId";
+        private static final UUID RESERVATION_ID = UUID.randomUUID();
+        private static final UUID ITINERARY_ID = UUID.randomUUID();
+        private static final UUID ROOM_ID = UUID.randomUUID();
+
+        @BeforeEach
+        void injectScheduler() throws Exception {
+                var field = ReservationServiceImpl.class.getDeclaredField("dbScheduler");
+                field.setAccessible(true);
+                field.set(reservationService, Schedulers.immediate());
+        }
+
+        // ─── 사용자 검증 ──────────────────────────────────────────────────────────
+
+        @Test
+        @DisplayName("존재하지 않는 사용자 - 404 예외")
+        void getReservations_userNotFound_throws404() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(false);
+
+                StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.NOT_FOUND)
+                                .verify();
+
+                verify(reservationRepository, never()).findByClerkIdWithFilters(any(), any(), any());
+        }
+
+        // ─── 파라미터 검증 ────────────────────────────────────────────────────────
+
+        @Test
+        @DisplayName("잘못된 type 파라미터 - 400 예외")
+        void getReservations_invalidType_throws400() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+                StepVerifier.create(reservationService.getReservations(CLERK_ID, "invalid", null))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("잘못된 status 파라미터 - 400 예외")
+        void getReservations_invalidStatus_throws400() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+                StepVerifier.create(reservationService.getReservations(CLERK_ID, null, "invalid"))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                                .verify();
+        }
+
+        // ─── 정상 조회 ────────────────────────────────────────────────────────────
+
+        @Test
+        @DisplayName("필터 없이 조회 - 전체 예약 목록 반환")
+        void getReservations_noFilters_returnsAll() throws Exception {
+                Reservation mockReservation = buildMockReservation("flight", "confirmed");
+
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, null, null))
+                                .thenReturn(List.of(mockReservation));
+                when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                                .thenReturn(Map.of());
+
+                StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
+                                .assertNext(response -> {
+                                        assertThat(response.reservations()).hasSize(1);
+                                        assertThat(response.reservations().get(0).type()).isEqualTo("flight");
+                                        assertThat(response.reservations().get(0).status()).isEqualTo("confirmed");
+                                })
+                                .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("type 필터 적용 - 리포지토리에 type 전달")
+        void getReservations_withTypeFilter_passedToRepository() throws Exception {
+                Reservation mockReservation = buildMockReservation("accommodation", "confirmed");
+
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, "accommodation", null))
+                                .thenReturn(List.of(mockReservation));
+                when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                                .thenReturn(Map.of());
+
+                StepVerifier.create(reservationService.getReservations(CLERK_ID, "accommodation", null))
+                                .assertNext(response -> assertThat(response.reservations()).hasSize(1))
+                                .verifyComplete();
+
+                verify(reservationRepository).findByClerkIdWithFilters(CLERK_ID, "accommodation", null);
+        }
+
+        @Test
+        @DisplayName("결과 없음 - 빈 목록 반환")
+        void getReservations_noResults_returnsEmptyList() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, null, null))
+                                .thenReturn(List.of());
+
+                StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
+                                .assertNext(response -> assertThat(response.reservations()).isEmpty())
+                                .verifyComplete();
+        }
+
+        // ─── createReservation: 사용자/파라미터 검증 ──────────────────────────────
+
+        @Test
+        @DisplayName("예약 생성 - 존재하지 않는 사용자 - 404 예외")
+        void createReservation_userNotFound_throws404() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(false);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.NOT_FOUND)
+                                .verify();
+
+                verify(itineraryRepository, never()).findById(any());
+        }
+
+        @Test
+        @DisplayName("예약 생성 - 잘못된 type - 400 예외")
+        void createReservation_invalidType_throws400() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("train", "ai")))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals(
+                                                                "type must be one of: flight, accommodation, car_rental."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 생성 - 잘못된 bookedBy - 400 예외")
+        void createReservation_invalidBookedBy_throws400() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "bot")))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals("bookedBy must be one of: user, ai."))
+                                .verify();
+        }
+
+        // ─── createReservation: 소유권 검증 ──────────────────────────────────────
+
+        @Test
+        @DisplayName("예약 생성 - 존재하지 않는 itinerary - 404 예외")
+        void createReservation_itineraryNotFound_throws404() {
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.NOT_FOUND
+                                                && rse.getReason().equals("Itinerary not found."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 생성 - 다른 사용자의 itinerary - 403 예외")
+        void createReservation_notOwner_throws403() {
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom otherChatRoom = mock(ChatRoom.class);
+                when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
+
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.FORBIDDEN)
+                                .verify();
+        }
+
+        // ─── createReservation: 정상 생성 ────────────────────────────────────────
+
+        @Test
+        @DisplayName("예약 생성 - 정상 요청 - 생성된 예약 반환")
+        void createReservation_success_returnsResponse() throws Exception {
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getId()).thenReturn(UUID.randomUUID());
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(mockReservation.getType()).thenReturn("flight");
+                when(mockReservation.getStatus()).thenReturn("confirmed");
+                when(mockReservation.getCreatedAt()).thenReturn(OffsetDateTime.now());
+
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+                when(objectMapper.writeValueAsString(any())).thenReturn("{\"airline\":\"대한항공\"}");
+                when(reservationRepository.save(any())).thenReturn(mockReservation);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                                .assertNext(response -> {
+                                        assertThat(response.reservationId()).isNotNull();
+                                        assertThat(response.type()).isEqualTo("flight");
+                                        assertThat(response.status()).isEqualTo("confirmed");
+                                })
+                                .verifyComplete();
+
+                verify(reservationRepository).save(any());
+        }
+
+        // ─── createReservation: detail 검증 ─────────────────────────────────────
+
+        @Test
+        @DisplayName("flight - 필수 detail 필드 누락 - 400 예외")
+        void createReservation_flightMissingDetailField_throws400() {
+                setupOwnerMocks();
+                Map<String, Object> invalidDetail = Map.of("airline", "대한항공", "flight_no", "KE123");
+                CreateReservationRequest request = new CreateReservationRequest(
+                                ITINERARY_ID, "flight", "ai", null, null, invalidDetail, null, null, null);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("flight - passengers 빈 배열 - 400 예외")
+        void createReservation_flightEmptyPassengers_throws400() {
+                setupOwnerMocks();
+                Map<String, Object> invalidDetail = new java.util.HashMap<>(buildValidDetail("flight"));
+                invalidDetail.put("passengers", List.of());
+                CreateReservationRequest request = new CreateReservationRequest(
+                                ITINERARY_ID, "flight", "ai", null, null, invalidDetail, null, null, null);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().contains("passengers"))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("flight - passenger에 passport 누락 - 400 예외")
+        void createReservation_flightPassengerMissingPassport_throws400() {
+                setupOwnerMocks();
+                Map<String, Object> invalidDetail = new java.util.HashMap<>(buildValidDetail("flight"));
+                invalidDetail.put("passengers", List.of(Map.of("name", "홍길동")));
+                CreateReservationRequest request = new CreateReservationRequest(
+                                ITINERARY_ID, "flight", "ai", null, null, invalidDetail, null, null, null);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().contains("passengers[0]"))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("accommodation - 필수 detail 필드 누락 - 400 예외")
+        void createReservation_accommodationMissingDetailField_throws400() {
+                setupOwnerMocks();
+                Map<String, Object> invalidDetail = Map.of("hotel_name", "롯데호텔");
+                CreateReservationRequest request = new CreateReservationRequest(
+                                ITINERARY_ID, "accommodation", "user", null, null, invalidDetail, null, null, null);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("car_rental - pickup 내 필수 필드 누락 - 400 예외")
+        void createReservation_carRentalMissingPickupField_throws400() {
+                setupOwnerMocks();
+                Map<String, Object> invalidDetail = new java.util.HashMap<>(buildValidDetail("car_rental"));
+                invalidDetail.put("pickup", Map.of("location", "NRT T1"));
+                CreateReservationRequest request = new CreateReservationRequest(
+                                ITINERARY_ID, "car_rental", "ai", null, null, invalidDetail, null, null, null);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().contains("pickup.datetime"))
+                                .verify();
+        }
+
+        // ─── updateReservation: 파라미터 검증 ────────────────────────────────────
+
+        @Test
+        @DisplayName("예약 수정 - 빈 body - 400 예외")
+        void updateReservation_emptyBody_throws400() {
+                PatchReservationRequest emptyRequest = new PatchReservationRequest(null, null, null, null, null, null);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, emptyRequest))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals("At least one field must be provided."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - 잘못된 status - 400 예외")
+        void updateReservation_invalidStatus_throws400() {
+                PatchReservationRequest request = new PatchReservationRequest("invalid", null, null, null, null, null);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals(
+                                                                "status must be one of: confirmed, changed, cancelled."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - 잘못된 detail 구조 - 400 예외")
+        void updateReservation_invalidDetail_throws400() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(mockReservation.getType()).thenReturn("flight");
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+
+                PatchReservationRequest request = new PatchReservationRequest(
+                        null, Map.of("airline", "대한항공"), null, null, null, null);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                                .verify();
+        }
+
+        // ─── updateReservation: 소유권 검증 ──────────────────────────────────────
+
+        @Test
+        @DisplayName("예약 수정 - 존재하지 않는 예약 - 404 예외")
+        void updateReservation_reservationNotFound_throws404() {
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("cancelled", null, null, null, null, null)))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.NOT_FOUND
+                                                && rse.getReason().equals("Reservation not found."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - 다른 사용자의 예약 - 403 예외")
+        void updateReservation_notOwner_throws403() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom otherChatRoom = mock(ChatRoom.class);
+                when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("cancelled", null, null, null, null, null)))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.FORBIDDEN)
+                                .verify();
+        }
+
+        // ─── updateReservation: 정상 수정 ────────────────────────────────────────
+
+        @Test
+        @DisplayName("예약 수정 - 상태 변경 - 수정된 예약 반환")
+        void updateReservation_statusChange_returnsResponse() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(mockReservation.getId()).thenReturn(RESERVATION_ID);
+                when(mockReservation.getStatus()).thenReturn("cancelled");
+                when(mockReservation.getUpdatedAt()).thenReturn(OffsetDateTime.now());
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+                when(reservationRepository.save(any())).thenReturn(mockReservation);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("cancelled", null, null, null, null, OffsetDateTime.now())))
+                                .assertNext(response -> {
+                                        assertThat(response.reservationId()).isEqualTo(RESERVATION_ID);
+                                        assertThat(response.status()).isEqualTo("cancelled");
+                                        assertThat(response.updatedAt()).isNotNull();
+                                })
+                                .verifyComplete();
+
+                verify(reservationRepository).save(mockReservation);
+        }
+
+        // ─── deleteReservation ────────────────────────────────────────────────────
+
+        @Test
+        @DisplayName("예약 삭제 - 존재하지 않는 예약 - 404 예외")
+        void deleteReservation_reservationNotFound_throws404() {
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.NOT_FOUND
+                                                && rse.getReason().equals("Reservation not found."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 삭제 - 다른 사용자의 예약 - 403 예외")
+        void deleteReservation_notOwner_throws403() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom otherChatRoom = mock(ChatRoom.class);
+                when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
+
+                StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.FORBIDDEN)
+                                .verify();
+
+                verify(reservationRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("예약 삭제 - 정상 요청 - delete 호출 후 완료")
+        void deleteReservation_success_completesAndCallsDelete() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+
+                StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                                .verifyComplete();
+
+                verify(reservationRepository).delete(mockReservation);
+        }
+
+        // ─── 헬퍼 ────────────────────────────────────────────────────────────────
+
+        private CreateReservationRequest buildCreateRequest(String type, String bookedBy) {
+                return new CreateReservationRequest(
+                                ITINERARY_ID,
+                                type,
+                                bookedBy,
+                                "https://booking.example.com/flight/123",
+                                "KE12345678",
+                                buildValidDetail(type),
+                                new BigDecimal("320000"),
+                                "KRW",
+                                OffsetDateTime.now());
+        }
+
+        private Map<String, Object> buildValidDetail(String type) {
+                return switch (type) {
+                        case "flight" -> Map.of(
+                                        "airline", "대한항공",
+                                        "flight_no", "KE123",
+                                        "departure", Map.of("airport", "ICN", "datetime", "2026-05-01T09:00:00"),
+                                        "arrival", Map.of("airport", "NRT", "datetime", "2026-05-01T11:30:00"),
+                                        "seat_class", "economy",
+                                        "passengers", List.of(Map.of("name", "홍길동", "passport", "M12345678")));
+                        case "accommodation" -> Map.of(
+                                        "hotel_name", "롯데호텔 도쿄",
+                                        "room_type", "디럭스 더블",
+                                        "check_in", "2026-05-01",
+                                        "check_out", "2026-05-03",
+                                        "guests", 2);
+                        case "car_rental" -> Map.of(
+                                        "company", "Hertz",
+                                        "car_model", "Toyota Camry",
+                                        "pickup", Map.of("location", "NRT T1", "datetime", "2026-05-01T13:00:00"),
+                                        "dropoff", Map.of("location", "NRT T1", "datetime", "2026-05-03T11:00:00"));
+                        default -> Map.of();
+                };
+        }
+
+        private void setupOwnerMocks() {
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+        }
+
+        private Reservation buildMockReservation(String type, String status) {
+                Reservation r = mock(Reservation.class);
+                when(r.getId()).thenReturn(UUID.randomUUID());
+                when(r.getItineraryId()).thenReturn(UUID.randomUUID());
+                when(r.getType()).thenReturn(type);
+                when(r.getStatus()).thenReturn(status);
+                when(r.getBookedBy()).thenReturn("ai");
+                when(r.getBookingUrl()).thenReturn(null);
+                when(r.getExternalRefId()).thenReturn("REF-001");
+                when(r.getDetail()).thenReturn("{}");
+                when(r.getTotalPrice()).thenReturn(BigDecimal.valueOf(350000));
+                when(r.getCurrency()).thenReturn("KRW");
+                when(r.getReservedAt()).thenReturn(OffsetDateTime.now());
+                when(r.getCancelledAt()).thenReturn(null);
+                when(r.getCreatedAt()).thenReturn(OffsetDateTime.now());
+                when(r.getUpdatedAt()).thenReturn(OffsetDateTime.now());
+                return r;
+        }
 }

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -7,6 +7,7 @@ import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
 import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
 import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
+import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
 import com.mju.capstone_backend.domain.reservation.entity.Reservation;
 import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
 import com.mju.capstone_backend.domain.user.repository.UserRepository;
@@ -56,6 +57,7 @@ class ReservationServiceImplTest {
     private ReservationServiceImpl reservationService;
 
     private static final String CLERK_ID = "user_testClerkId";
+    private static final UUID RESERVATION_ID = UUID.randomUUID();
     private static final UUID ITINERARY_ID = UUID.randomUUID();
     private static final UUID ROOM_ID = UUID.randomUUID();
 
@@ -260,6 +262,100 @@ class ReservationServiceImplTest {
                 .verifyComplete();
 
         verify(reservationRepository).save(any());
+    }
+
+    // ─── updateReservation: 파라미터 검증 ────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 수정 - 빈 body - 400 예외")
+    void updateReservation_emptyBody_throws400() {
+        PatchReservationRequest emptyRequest = new PatchReservationRequest(null, null, null, null, null, null);
+
+        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, emptyRequest))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                        && rse.getReason().equals("At least one field must be provided."))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("예약 수정 - 잘못된 status - 400 예외")
+    void updateReservation_invalidStatus_throws400() {
+        PatchReservationRequest request = new PatchReservationRequest("invalid", null, null, null, null, null);
+
+        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                        && rse.getReason().equals("status must be one of: confirmed, changed, cancelled."))
+                .verify();
+    }
+
+    // ─── updateReservation: 소유권 검증 ──────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 수정 - 존재하지 않는 예약 - 404 예외")
+    void updateReservation_reservationNotFound_throws404() {
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                        new PatchReservationRequest("cancelled", null, null, null, null, null)))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.NOT_FOUND
+                        && rse.getReason().equals("Reservation not found."))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("예약 수정 - 다른 사용자의 예약 - 403 예외")
+    void updateReservation_notOwner_throws403() {
+        Reservation mockReservation = mock(Reservation.class);
+        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+        Itinerary mockItinerary = mock(Itinerary.class);
+        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+        ChatRoom otherChatRoom = mock(ChatRoom.class);
+        when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
+
+        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                        new PatchReservationRequest("cancelled", null, null, null, null, null)))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.FORBIDDEN)
+                .verify();
+    }
+
+    // ─── updateReservation: 정상 수정 ────────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 수정 - 상태 변경 - 수정된 예약 반환")
+    void updateReservation_statusChange_returnsResponse() {
+        Reservation mockReservation = mock(Reservation.class);
+        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+        when(mockReservation.getId()).thenReturn(RESERVATION_ID);
+        when(mockReservation.getStatus()).thenReturn("cancelled");
+        when(mockReservation.getUpdatedAt()).thenReturn(OffsetDateTime.now());
+        Itinerary mockItinerary = mock(Itinerary.class);
+        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+        when(reservationRepository.save(any())).thenReturn(mockReservation);
+
+        StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                        new PatchReservationRequest("cancelled", null, null, null, null, OffsetDateTime.now())))
+                .assertNext(response -> {
+                    assertThat(response.reservationId()).isEqualTo(RESERVATION_ID);
+                    assertThat(response.status()).isEqualTo("cancelled");
+                    assertThat(response.updatedAt()).isNotNull();
+                })
+                .verifyComplete();
+
+        verify(reservationRepository).save(mockReservation);
     }
 
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -358,6 +358,62 @@ class ReservationServiceImplTest {
         verify(reservationRepository).save(mockReservation);
     }
 
+    // ─── deleteReservation ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 삭제 - 존재하지 않는 예약 - 404 예외")
+    void deleteReservation_reservationNotFound_throws404() {
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.NOT_FOUND
+                        && rse.getReason().equals("Reservation not found."))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("예약 삭제 - 다른 사용자의 예약 - 403 예외")
+    void deleteReservation_notOwner_throws403() {
+        Reservation mockReservation = mock(Reservation.class);
+        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+        Itinerary mockItinerary = mock(Itinerary.class);
+        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+        ChatRoom otherChatRoom = mock(ChatRoom.class);
+        when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
+
+        StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.FORBIDDEN)
+                .verify();
+
+        verify(reservationRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("예약 삭제 - 정상 요청 - delete 호출 후 완료")
+    void deleteReservation_success_completesAndCallsDelete() {
+        Reservation mockReservation = mock(Reservation.class);
+        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+        Itinerary mockItinerary = mock(Itinerary.class);
+        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+
+        StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                .verifyComplete();
+
+        verify(reservationRepository).delete(mockReservation);
+    }
+
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────
 
     private CreateReservationRequest buildCreateRequest(String type, String bookedBy) {

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -1,0 +1,166 @@
+package com.mju.capstone_backend.domain.reservation.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mju.capstone_backend.domain.reservation.entity.Reservation;
+import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
+import com.mju.capstone_backend.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationServiceImpl 단위 테스트")
+class ReservationServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ReservationServiceImpl reservationService;
+
+    private static final String CLERK_ID = "user_testClerkId";
+
+    @BeforeEach
+    void injectScheduler() throws Exception {
+        var field = ReservationServiceImpl.class.getDeclaredField("dbScheduler");
+        field.setAccessible(true);
+        field.set(reservationService, Schedulers.immediate());
+    }
+
+    // ─── 사용자 검증 ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 - 404 예외")
+    void getReservations_userNotFound_throws404() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(false);
+
+        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.NOT_FOUND)
+                .verify();
+
+        verify(reservationRepository, never()).findByClerkIdWithFilters(any(), any(), any());
+    }
+
+    // ─── 파라미터 검증 ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("잘못된 type 파라미터 - 400 예외")
+    void getReservations_invalidType_throws400() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+        StepVerifier.create(reservationService.getReservations(CLERK_ID, "invalid", null))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("잘못된 status 파라미터 - 400 예외")
+    void getReservations_invalidStatus_throws400() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, "invalid"))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST)
+                .verify();
+    }
+
+    // ─── 정상 조회 ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("필터 없이 조회 - 전체 예약 목록 반환")
+    void getReservations_noFilters_returnsAll() throws Exception {
+        Reservation mockReservation = buildMockReservation("flight", "confirmed");
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, null, null))
+                .thenReturn(List.of(mockReservation));
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of());
+
+        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
+                .assertNext(response -> {
+                    assertThat(response.reservations()).hasSize(1);
+                    assertThat(response.reservations().get(0).type()).isEqualTo("flight");
+                    assertThat(response.reservations().get(0).status()).isEqualTo("confirmed");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("type 필터 적용 - 리포지토리에 type 전달")
+    void getReservations_withTypeFilter_passedToRepository() throws Exception {
+        Reservation mockReservation = buildMockReservation("accommodation", "confirmed");
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, "accommodation", null))
+                .thenReturn(List.of(mockReservation));
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of());
+
+        StepVerifier.create(reservationService.getReservations(CLERK_ID, "accommodation", null))
+                .assertNext(response -> assertThat(response.reservations()).hasSize(1))
+                .verifyComplete();
+
+        verify(reservationRepository).findByClerkIdWithFilters(CLERK_ID, "accommodation", null);
+    }
+
+    @Test
+    @DisplayName("결과 없음 - 빈 목록 반환")
+    void getReservations_noResults_returnsEmptyList() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(reservationRepository.findByClerkIdWithFilters(CLERK_ID, null, null))
+                .thenReturn(List.of());
+
+        StepVerifier.create(reservationService.getReservations(CLERK_ID, null, null))
+                .assertNext(response -> assertThat(response.reservations()).isEmpty())
+                .verifyComplete();
+    }
+
+    // ─── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    private Reservation buildMockReservation(String type, String status) {
+        Reservation r = mock(Reservation.class);
+        when(r.getId()).thenReturn(UUID.randomUUID());
+        when(r.getItineraryId()).thenReturn(UUID.randomUUID());
+        when(r.getType()).thenReturn(type);
+        when(r.getStatus()).thenReturn(status);
+        when(r.getBookedBy()).thenReturn("ai");
+        when(r.getBookingUrl()).thenReturn(null);
+        when(r.getExternalRefId()).thenReturn("REF-001");
+        when(r.getDetail()).thenReturn("{}");
+        when(r.getTotalPrice()).thenReturn(BigDecimal.valueOf(350000));
+        when(r.getCurrency()).thenReturn("KRW");
+        when(r.getReservedAt()).thenReturn(OffsetDateTime.now());
+        when(r.getCancelledAt()).thenReturn(null);
+        when(r.getCreatedAt()).thenReturn(OffsetDateTime.now());
+        when(r.getUpdatedAt()).thenReturn(OffsetDateTime.now());
+        return r;
+    }
+}

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -6,6 +6,8 @@ import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
 import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
 import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.reservation.dto.CancelReservationResponse;
+import com.mju.capstone_backend.domain.reservation.dto.ChangeReservationResponse;
 import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.dto.PatchReservationRequest;
 import com.mju.capstone_backend.domain.reservation.entity.Reservation;
@@ -232,6 +234,23 @@ class ReservationServiceImplTest {
                                 .verify();
         }
 
+        @Test
+        @DisplayName("예약 생성 - chatRoom 없음 - 500 예외")
+        void createReservation_chatRoomNotFound_throws500() {
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+
+                when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR
+                                                && rse.getReason().equals("Related chat room data is missing."))
+                                .verify();
+        }
+
         // ─── createReservation: 정상 생성 ────────────────────────────────────────
 
         @Test
@@ -343,6 +362,22 @@ class ReservationServiceImplTest {
                                 .verify();
         }
 
+        @Test
+        @DisplayName("flight - 중첩 필드 빈 문자열 - 400 예외")
+        void createReservation_flightBlankNestedField_throws400() {
+                setupOwnerMocks();
+                Map<String, Object> invalidDetail = new java.util.HashMap<>(buildValidDetail("flight"));
+                invalidDetail.put("arrival", Map.of("airport", "", "datetime", "2026-05-01T11:30:00"));
+                CreateReservationRequest request = new CreateReservationRequest(
+                                ITINERARY_ID, "flight", "ai", null, null, invalidDetail, null, null, null);
+
+                StepVerifier.create(reservationService.createReservation(CLERK_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().contains("arrival.airport"))
+                                .verify();
+        }
+
         // ─── updateReservation: 파라미터 검증 ────────────────────────────────────
 
         @Test
@@ -366,7 +401,61 @@ class ReservationServiceImplTest {
                                 .expectErrorMatches(e -> e instanceof ResponseStatusException rse
                                                 && rse.getStatusCode() == HttpStatus.BAD_REQUEST
                                                 && rse.getReason().equals(
-                                                                "status must be one of: confirmed, changed, cancelled."))
+                                                                "status must be one of: changed, cancelled."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - status: confirmed (허용 불가) - 400 예외")
+        void updateReservation_confirmedStatus_throws400() {
+                PatchReservationRequest request = new PatchReservationRequest("confirmed", null, null, null, null, null);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals(
+                                                                "status must be one of: changed, cancelled."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - status: cancelled인데 cancelledAt 누락 - 400 예외")
+        void updateReservation_cancelledWithoutCancelledAt_throws400() {
+                setupUpdateOwnerMocks("confirmed");
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("cancelled", null, null, null, null, null)))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals("cancelledAt is required when status is cancelled."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - status: changed인데 필수 필드 누락 - 400 예외")
+        void updateReservation_changedWithoutRequiredFields_throws400() {
+                setupUpdateOwnerMocks("confirmed");
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("changed", null, null, null, null, null)))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals(
+                                                                "detail, reservedAt are required when status is changed."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - 이미 취소된 예약 - 400 예외")
+        void updateReservation_alreadyCancelled_throws400() {
+                setupUpdateOwnerMocks("cancelled");
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("changed", null, null, null, null, null)))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals(
+                                                                "Cannot update a reservation that has already been cancelled."))
                                 .verify();
         }
 
@@ -394,6 +483,76 @@ class ReservationServiceImplTest {
                                 .verify();
         }
 
+        @Test
+        @DisplayName("예약 수정 - detail.{parent}가 객체 아님 - 400 예외")
+        void updateReservation_detailParentNotObject_throws400() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(mockReservation.getStatus()).thenReturn("confirmed");
+                when(mockReservation.getType()).thenReturn("flight");
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+
+                Map<String, Object> badDetail = new java.util.HashMap<>(buildValidDetail("flight"));
+                badDetail.put("departure", "ICN");
+                PatchReservationRequest request = new PatchReservationRequest(
+                        null, badDetail, null, null, OffsetDateTime.now(), null);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals("detail.departure must be an object for type 'flight'."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - 중첩 detail 필드 빈 문자열 - 400 예외")
+        void updateReservation_blankNestedDetailField_throws400() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(mockReservation.getStatus()).thenReturn("confirmed");
+                when(mockReservation.getType()).thenReturn("flight");
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+
+                Map<String, Object> badDetail = new java.util.HashMap<>(buildValidDetail("flight"));
+                badDetail.put("arrival", Map.of("airport", "", "datetime", "2026-05-01T11:30:00"));
+                PatchReservationRequest request = new PatchReservationRequest(
+                        null, badDetail, null, null, OffsetDateTime.now(), null);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID, request))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals("detail.arrival.airport is required for type 'flight'."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - status: changed인데 reservedAt만 누락 - 400 예외")
+        void updateReservation_changedMissingOnlyReservedAt_throws400() {
+                setupUpdateOwnerMocks("confirmed");
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("changed", buildValidDetail("flight"), null, null, null, null)))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                                                && rse.getReason().equals(
+                                                                "detail, reservedAt are required when status is changed."))
+                                .verify();
+        }
+
         // ─── updateReservation: 소유권 검증 ──────────────────────────────────────
 
         @Test
@@ -406,6 +565,43 @@ class ReservationServiceImplTest {
                                 .expectErrorMatches(e -> e instanceof ResponseStatusException rse
                                                 && rse.getStatusCode() == HttpStatus.NOT_FOUND
                                                 && rse.getReason().equals("Reservation not found."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - itinerary 없음 - 500 예외")
+        void updateReservation_itineraryNotFound_throws500() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("cancelled", null, null, null, null, OffsetDateTime.now())))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR
+                                                && rse.getReason().equals("Related itinerary data is missing."))
+                                .verify();
+        }
+
+        @Test
+        @DisplayName("예약 수정 - chatRoom 없음 - 500 예외")
+        void updateReservation_chatRoomNotFound_throws500() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("cancelled", null, null, null, null, OffsetDateTime.now())))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR
+                                                && rse.getReason().equals("Related chat room data is missing."))
                                 .verify();
         }
 
@@ -433,33 +629,80 @@ class ReservationServiceImplTest {
         // ─── updateReservation: 정상 수정 ────────────────────────────────────────
 
         @Test
-        @DisplayName("예약 수정 - 상태 변경 - 수정된 예약 반환")
-        void updateReservation_statusChange_returnsResponse() {
-                Reservation mockReservation = mock(Reservation.class);
-                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
-                when(mockReservation.getId()).thenReturn(RESERVATION_ID);
-                when(mockReservation.getStatus()).thenReturn("cancelled");
-                when(mockReservation.getUpdatedAt()).thenReturn(OffsetDateTime.now());
+        @DisplayName("예약 취소 - 정상 요청 - CancelReservationResponse 반환")
+        void updateReservation_cancel_returnsCancelResponse() {
+                OffsetDateTime cancelledAt = OffsetDateTime.now();
+                Reservation existing = mock(Reservation.class);
+                when(existing.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(existing.getStatus()).thenReturn("confirmed");
+                Reservation saved = mock(Reservation.class);
+                when(saved.getId()).thenReturn(RESERVATION_ID);
+                when(saved.getStatus()).thenReturn("cancelled");
+                when(saved.getCancelledAt()).thenReturn(cancelledAt);
+                when(saved.getUpdatedAt()).thenReturn(OffsetDateTime.now());
                 Itinerary mockItinerary = mock(Itinerary.class);
                 when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
                 ChatRoom mockChatRoom = mock(ChatRoom.class);
                 when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
 
-                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(existing));
                 when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
                 when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
-                when(reservationRepository.save(any())).thenReturn(mockReservation);
+                when(reservationRepository.save(any())).thenReturn(saved);
 
                 StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
-                                new PatchReservationRequest("cancelled", null, null, null, null, OffsetDateTime.now())))
+                                new PatchReservationRequest("cancelled", null, null, null, null, cancelledAt)))
                                 .assertNext(response -> {
-                                        assertThat(response.reservationId()).isEqualTo(RESERVATION_ID);
-                                        assertThat(response.status()).isEqualTo("cancelled");
-                                        assertThat(response.updatedAt()).isNotNull();
+                                        assertThat(response).isInstanceOf(CancelReservationResponse.class);
+                                        CancelReservationResponse r = (CancelReservationResponse) response;
+                                        assertThat(r.reservationId()).isEqualTo(RESERVATION_ID);
+                                        assertThat(r.status()).isEqualTo("cancelled");
+                                        assertThat(r.cancelledAt()).isEqualTo(cancelledAt);
+                                        assertThat(r.updatedAt()).isNotNull();
                                 })
                                 .verifyComplete();
 
-                verify(reservationRepository).save(mockReservation);
+                verify(reservationRepository).save(existing);
+        }
+
+        @Test
+        @DisplayName("예약 변경 - 정상 요청 - ChangeReservationResponse 반환")
+        void updateReservation_change_returnsChangeResponse() throws Exception {
+                OffsetDateTime reservedAt = OffsetDateTime.now();
+                Reservation existing = mock(Reservation.class);
+                when(existing.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(existing.getStatus()).thenReturn("confirmed");
+                when(existing.getType()).thenReturn("flight");
+                Reservation saved = mock(Reservation.class);
+                when(saved.getId()).thenReturn(RESERVATION_ID);
+                when(saved.getStatus()).thenReturn("changed");
+                when(saved.getReservedAt()).thenReturn(reservedAt);
+                when(saved.getUpdatedAt()).thenReturn(OffsetDateTime.now());
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(existing));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+                when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+                when(reservationRepository.save(any())).thenReturn(saved);
+
+                StepVerifier.create(reservationService.updateReservation(CLERK_ID, RESERVATION_ID,
+                                new PatchReservationRequest("changed", buildValidDetail("flight"),
+                                                new BigDecimal("290000"), "KRW", reservedAt, null)))
+                                .assertNext(response -> {
+                                        assertThat(response).isInstanceOf(ChangeReservationResponse.class);
+                                        ChangeReservationResponse r = (ChangeReservationResponse) response;
+                                        assertThat(r.reservationId()).isEqualTo(RESERVATION_ID);
+                                        assertThat(r.status()).isEqualTo("changed");
+                                        assertThat(r.reservedAt()).isEqualTo(reservedAt);
+                                        assertThat(r.updatedAt()).isNotNull();
+                                })
+                                .verifyComplete();
+
+                verify(reservationRepository).save(existing);
         }
 
         // ─── deleteReservation ────────────────────────────────────────────────────
@@ -474,6 +717,45 @@ class ReservationServiceImplTest {
                                                 && rse.getStatusCode() == HttpStatus.NOT_FOUND
                                                 && rse.getReason().equals("Reservation not found."))
                                 .verify();
+        }
+
+        @Test
+        @DisplayName("예약 삭제 - itinerary 없음 - 500 예외")
+        void deleteReservation_itineraryNotFound_throws500() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR
+                                                && rse.getReason().equals("Related itinerary data is missing."))
+                                .verify();
+
+                verify(reservationRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("예약 삭제 - chatRoom 없음 - 500 예외")
+        void deleteReservation_chatRoomNotFound_throws500() {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.empty());
+
+                StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                                                && rse.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR
+                                                && rse.getReason().equals("Related chat room data is missing."))
+                                .verify();
+
+                verify(reservationRepository, never()).delete(any());
         }
 
         @Test
@@ -559,6 +841,20 @@ class ReservationServiceImplTest {
                                         "dropoff", Map.of("location", "NRT T1", "datetime", "2026-05-03T11:00:00"));
                         default -> Map.of();
                 };
+        }
+
+        private void setupUpdateOwnerMocks(String currentStatus) {
+                Reservation mockReservation = mock(Reservation.class);
+                when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+                when(mockReservation.getStatus()).thenReturn(currentStatus);
+                Itinerary mockItinerary = mock(Itinerary.class);
+                when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+                ChatRoom mockChatRoom = mock(ChatRoom.class);
+                when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+
+                when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(mockReservation));
+                when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+                when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
         }
 
         private void setupOwnerMocks() {

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -2,6 +2,11 @@ package com.mju.capstone_backend.domain.reservation.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
+import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
+import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
+import com.mju.capstone_backend.domain.itinerary.repository.ItineraryRepository;
+import com.mju.capstone_backend.domain.reservation.dto.CreateReservationRequest;
 import com.mju.capstone_backend.domain.reservation.entity.Reservation;
 import com.mju.capstone_backend.domain.reservation.repository.ReservationRepository;
 import com.mju.capstone_backend.domain.user.repository.UserRepository;
@@ -21,6 +26,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +41,12 @@ class ReservationServiceImplTest {
     private UserRepository userRepository;
 
     @Mock
+    private ItineraryRepository itineraryRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
     private ReservationRepository reservationRepository;
 
     @Mock
@@ -44,6 +56,8 @@ class ReservationServiceImplTest {
     private ReservationServiceImpl reservationService;
 
     private static final String CLERK_ID = "user_testClerkId";
+    private static final UUID ITINERARY_ID = UUID.randomUUID();
+    private static final UUID ROOM_ID = UUID.randomUUID();
 
     @BeforeEach
     void injectScheduler() throws Exception {
@@ -143,7 +157,132 @@ class ReservationServiceImplTest {
                 .verifyComplete();
     }
 
+    // ─── createReservation: 사용자/파라미터 검증 ──────────────────────────────
+
+    @Test
+    @DisplayName("예약 생성 - 존재하지 않는 사용자 - 404 예외")
+    void createReservation_userNotFound_throws404() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(false);
+
+        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.NOT_FOUND)
+                .verify();
+
+        verify(itineraryRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("예약 생성 - 잘못된 type - 400 예외")
+    void createReservation_invalidType_throws400() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("train", "ai")))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                        && rse.getReason().equals("type must be one of: flight, accommodation, car_rental."))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("예약 생성 - 잘못된 bookedBy - 400 예외")
+    void createReservation_invalidBookedBy_throws400() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+
+        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "bot")))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.BAD_REQUEST
+                        && rse.getReason().equals("bookedBy must be one of: user, ai."))
+                .verify();
+    }
+
+    // ─── createReservation: 소유권 검증 ──────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 생성 - 존재하지 않는 itinerary - 404 예외")
+    void createReservation_itineraryNotFound_throws404() {
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.NOT_FOUND
+                        && rse.getReason().equals("Itinerary not found."))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("예약 생성 - 다른 사용자의 itinerary - 403 예외")
+    void createReservation_notOwner_throws403() {
+        Itinerary mockItinerary = mock(Itinerary.class);
+        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+        ChatRoom otherChatRoom = mock(ChatRoom.class);
+        when(otherChatRoom.getClerkId()).thenReturn("user_otherClerkId");
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(otherChatRoom));
+
+        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
+                        && rse.getStatusCode() == HttpStatus.FORBIDDEN)
+                .verify();
+    }
+
+    // ─── createReservation: 정상 생성 ────────────────────────────────────────
+
+    @Test
+    @DisplayName("예약 생성 - 정상 요청 - 생성된 예약 반환")
+    void createReservation_success_returnsResponse() throws Exception {
+        Itinerary mockItinerary = mock(Itinerary.class);
+        when(mockItinerary.getRoomId()).thenReturn(ROOM_ID);
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        when(mockChatRoom.getClerkId()).thenReturn(CLERK_ID);
+        Reservation mockReservation = mock(Reservation.class);
+        when(mockReservation.getId()).thenReturn(UUID.randomUUID());
+        when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
+        when(mockReservation.getType()).thenReturn("flight");
+        when(mockReservation.getStatus()).thenReturn("confirmed");
+        when(mockReservation.getCreatedAt()).thenReturn(OffsetDateTime.now());
+
+        when(userRepository.existsById(CLERK_ID)).thenReturn(true);
+        when(itineraryRepository.findById(ITINERARY_ID)).thenReturn(Optional.of(mockItinerary));
+        when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"airline\":\"대한항공\"}");
+        when(reservationRepository.save(any())).thenReturn(mockReservation);
+
+        StepVerifier.create(reservationService.createReservation(CLERK_ID, buildCreateRequest("flight", "ai")))
+                .assertNext(response -> {
+                    assertThat(response.reservationId()).isNotNull();
+                    assertThat(response.type()).isEqualTo("flight");
+                    assertThat(response.status()).isEqualTo("confirmed");
+                })
+                .verifyComplete();
+
+        verify(reservationRepository).save(any());
+    }
+
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    private CreateReservationRequest buildCreateRequest(String type, String bookedBy) {
+        return new CreateReservationRequest(
+                ITINERARY_ID,
+                type,
+                bookedBy,
+                "https://booking.example.com/flight/123",
+                "KE12345678",
+                Map.of("airline", "대한항공", "flight_no", "KE123"),
+                new BigDecimal("320000"),
+                "KRW",
+                OffsetDateTime.now()
+        );
+    }
+
+    private Itinerary buildMockItinerary() {
+        Itinerary itinerary = mock(Itinerary.class);
+        when(itinerary.getRoomId()).thenReturn(ROOM_ID);
+        return itinerary;
+    }
 
     private Reservation buildMockReservation(String type, String status) {
         Reservation r = mock(Reservation.class);

--- a/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/reservation/service/ReservationServiceImplTest.java
@@ -499,8 +499,8 @@ class ReservationServiceImplTest {
         }
 
         @Test
-        @DisplayName("예약 삭제 - 정상 요청 - delete 호출 후 완료")
-        void deleteReservation_success_completesAndCallsDelete() {
+        @DisplayName("예약 삭제 - 정상 요청 - reservationId와 deleted:true 반환")
+        void deleteReservation_success_returnsResponse() {
                 Reservation mockReservation = mock(Reservation.class);
                 when(mockReservation.getItineraryId()).thenReturn(ITINERARY_ID);
                 Itinerary mockItinerary = mock(Itinerary.class);
@@ -513,6 +513,10 @@ class ReservationServiceImplTest {
                 when(chatRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(mockChatRoom));
 
                 StepVerifier.create(reservationService.deleteReservation(CLERK_ID, RESERVATION_ID))
+                                .assertNext(response -> {
+                                        assertThat(response.reservationId()).isEqualTo(RESERVATION_ID);
+                                        assertThat(response.deleted()).isTrue();
+                                })
                                 .verifyComplete();
 
                 verify(reservationRepository).delete(mockReservation);


### PR DESCRIPTION
# 요약
`reservations` 도메인 CRUD 전체 구현했습니다.
JWT에서 clerkId를 추출해 본인 소유 권한을 검증하며, 4개 엔드포인트를 제공합니다.
- `GET` — type·status 쿼리 파라미터 필터링, users → chat_rooms → itineraries → reservations 조인
- `POST` — 레코드 생성 (type·bookedBy 유효성 검증)
- `PATCH` — 예약 상태·detail·가격 등 부분 수정 (최소 1개 필드 필수)
- `DELETE` — 레코드 완전 삭제

각 엔드포인트에 대해 서비스 단위 테스트(404/403/400/정상)와 컨트롤러 슬라이스 테스트(JWT 인증·에러 전파) 작성.        
로컬 개발용 시드 엔드포인트(`DevReservationController`) 포함.

# 연관 이슈 및 Close 할 이슈 작성
close #16

# Pull Request 체크리스트
- [x] 🔥 `ReservationController` 구현
  - [x] `GET /api/v1/reservations` — 내 예약 목록 조회 (type/status 필터)
  - [x] `POST /api/v1/reservations` — 예약 생성
  - [x] `PATCH /api/v1/reservations/{id}` — 예약 수정
  - [x] `DELETE /api/v1/reservations/{id}` — 예약 삭제
- [x] 🔥 `ReservationService` / `ReservationServiceImpl` 구현
  - [x] User 존재 확인(404) 및 본인 소유 권한 검증(403)
  - [x] type·status 유효성 검증(400)
  - [x] 동적 쿼리를 통한 필터링 및 updated_at DESC 정렬 로직
- [x] 🔥 `ReservationRepository` 쿼리 추가
  - [x] `clerk_id` 기준 `users → chat_rooms → itineraries → reservations` 조인
  - [x] type·status 동적 필터 지원
- [x] 🔥 DTO 생성 및 에러 핸들링
   - [x] GetReservationsResponse — 목록 조회용 응답 DTO
   - [x] CreateReservationRequest / CreateReservationResponse — 생성 요청/응답 DTO
   - [x] UpdateReservationRequest / UpdateReservationResponse — 수정 요청/응답 DTO
   - [x] GlobalExceptionHandler를 통한 400, 401, 403, 404, 500 응답 규격 확인
- [x] 🔥 `ReservationServiceImplTest` 작성 — User 없음(404), 잘못된 type·status(400), 정상 조회, 빈 목록 단위 테스트
- [x] 🔥 `ReservationControllerTest` 작성 — JWT 인증(200/401), type·status 필터 전달, 에러 전파(400/404) 슬라이스 테스트
- [x] 🔥 `DevReservationController` 추가 — `POST /dev/reservations/seed` 샘플 예약 3건 생성, `DELETE /dev/reservations/seed/{itineraryId}` 시드 데이터 삭제

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?