### PR TITLE
[Chore/#22] 트랜잭션 관리를 위한 TransactionTemplate 추가

### DIFF
--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -17,6 +17,7 @@ import com.mju.capstone_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -36,6 +37,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final ReservationRepository reservationRepository;
     private final Scheduler dbScheduler;
     private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     public Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request) {
@@ -56,29 +58,30 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
             long totalDays = ChronoUnit.DAYS.between(request.startDate(), request.endDate()) + 1;
             String name = (totalDays - 1) + "박 " + totalDays + "일 " + request.destination() + " 여행";
-            ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.of(clerkId, name));
 
-            Itinerary itinerary = itineraryRepository.save(
-                    Itinerary.of(
-                            chatRoom.getId(),
-                            request.destination(),
-                            request.startDate(),
-                            request.endDate(),
-                            request.budget(),
-                            request.adultCount(),
-                            request.childCount(),
-                            request.childAges()
-                    )
-            );
-
-            return new CreateChatRoomResponse(
-                    chatRoom.getId(),
-                    chatRoom.getName(),
-                    itinerary.getId(),
-                    chatRoom.getClerkId(),
-                    chatRoom.getCreatedAt(),
-                    chatRoom.getUpdatedAt()
-            );
+            return transactionTemplate.execute(status -> {
+                ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.of(clerkId, name));
+                Itinerary itinerary = itineraryRepository.save(
+                        Itinerary.of(
+                                chatRoom.getId(),
+                                request.destination(),
+                                request.startDate(),
+                                request.endDate(),
+                                request.budget(),
+                                request.adultCount(),
+                                request.childCount(),
+                                request.childAges()
+                        )
+                );
+                return new CreateChatRoomResponse(
+                        chatRoom.getId(),
+                        chatRoom.getName(),
+                        itinerary.getId(),
+                        chatRoom.getClerkId(),
+                        chatRoom.getCreatedAt(),
+                        chatRoom.getUpdatedAt()
+                );
+            });
         }).subscribeOn(dbScheduler)
                 .onErrorMap(
                         e -> !(e instanceof ResponseStatusException),

--- a/src/main/java/com/mju/capstone_backend/domain/itinerary/service/ItineraryServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/itinerary/service/ItineraryServiceImpl.java
@@ -24,6 +24,7 @@ import com.mju.capstone_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -53,6 +54,7 @@ public class ItineraryServiceImpl implements ItineraryService {
     private final ChatRoomRepository chatRoomRepository;
     private final ObjectMapper objectMapper;
     private final Scheduler dbScheduler;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     public Mono<GetItinerariesResponse> getItineraries(String clerkId) {
@@ -221,8 +223,6 @@ public class ItineraryServiceImpl implements ItineraryService {
                         "No changes detected. The submitted values are identical to the current data.");
             }
 
-            itineraryLogRepository.save(ItineraryLog.of(itinerary));
-
             boolean dateChanged = !effectiveStart.equals(itinerary.getStartDate())
                     || !effectiveEnd.equals(itinerary.getEndDate());
 
@@ -230,14 +230,16 @@ public class ItineraryServiceImpl implements ItineraryService {
                     ? adjustDayPlans(itinerary.getDayPlans(), effectiveStart, effectiveEnd)
                     : null;
 
-            itinerary.updateBasicInfo(
-                    request.startDate(), request.endDate(),
-                    request.budget(),
-                    request.adultCount(),
-                    request.childCount(), request.childAges(),
-                    updatedDayPlans);
-
-            itineraryRepository.save(itinerary);
+            transactionTemplate.executeWithoutResult(status -> {
+                itineraryLogRepository.save(ItineraryLog.of(itinerary));
+                itinerary.updateBasicInfo(
+                        request.startDate(), request.endDate(),
+                        request.budget(),
+                        request.adultCount(),
+                        request.childCount(), request.childAges(),
+                        updatedDayPlans);
+                itineraryRepository.save(itinerary);
+            });
 
             return new PatchItineraryResponse(
                     itinerary.getId(),
@@ -329,10 +331,13 @@ public class ItineraryServiceImpl implements ItineraryService {
                         "No changes detected. The submitted day plans are identical to the current data.");
             }
 
-            itineraryLogRepository.save(ItineraryLog.of(itinerary));
+            String resultJson = objectMapper.writeValueAsString(result);
 
-            itinerary.updateDayPlans(objectMapper.writeValueAsString(result));
-            itineraryRepository.save(itinerary);
+            transactionTemplate.executeWithoutResult(status -> {
+                itineraryLogRepository.save(ItineraryLog.of(itinerary));
+                itinerary.updateDayPlans(resultJson);
+                itineraryRepository.save(itinerary);
+            });
 
             return new PatchDayPlansResponse(itinerary.getId(), result, itinerary.getUpdatedAt());
         }).subscribeOn(dbScheduler)

--- a/src/main/java/com/mju/capstone_backend/global/config/DatabaseConfig.java
+++ b/src/main/java/com/mju/capstone_backend/global/config/DatabaseConfig.java
@@ -3,6 +3,8 @@ package com.mju.capstone_backend.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import java.util.concurrent.Executors;
@@ -17,5 +19,10 @@ public class DatabaseConfig {
     public Scheduler dbScheduler() {
         // 일꾼 20명을 생성하여 properties에서 설정한 커넥션 20개와 1:1 대응시킴
         return Schedulers.fromExecutor(Executors.newFixedThreadPool(dbPoolSize));
+    }
+
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
     }
 }

--- a/src/test/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImplTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
@@ -55,6 +57,9 @@ class ChatRoomServiceImplTest {
     @Mock
     private ObjectMapper objectMapper;
 
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
     @InjectMocks
     private ChatRoomServiceImpl chatRoomService;
 
@@ -67,6 +72,13 @@ class ChatRoomServiceImplTest {
         var field = ChatRoomServiceImpl.class.getDeclaredField("dbScheduler");
         field.setAccessible(true);
         field.set(chatRoomService, Schedulers.immediate());
+
+        // transactionTemplate.execute()가 콜백을 실제로 실행하도록 설정
+        // lenient: 트랜잭션을 거치지 않는 에러 경로 테스트에서 "unused stubbing" 경고 방지
+        lenient().when(transactionTemplate.execute(any())).thenAnswer(inv -> {
+            TransactionCallback<?> callback = inv.getArgument(0);
+            return callback.doInTransaction(null);
+        });
     }
 
     // ─── createChatRoom ───────────────────────────────────────────────────────

--- a/src/test/java/com/mju/capstone_backend/domain/itinerary/service/ItineraryServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/itinerary/service/ItineraryServiceImplTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
@@ -36,6 +37,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -58,6 +61,9 @@ class ItineraryServiceImplTest {
     @Mock
     private ChatRoomRepository chatRoomRepository;
 
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
     @InjectMocks
     private ItineraryServiceImpl itineraryService;
 
@@ -74,6 +80,14 @@ class ItineraryServiceImplTest {
         var mapperField = ItineraryServiceImpl.class.getDeclaredField("objectMapper");
         mapperField.setAccessible(true);
         mapperField.set(itineraryService, new ObjectMapper());
+
+        // transactionTemplate.executeWithoutResult()가 콜백을 실제로 실행하도록 설정
+        // lenient: 트랜잭션을 거치지 않는 에러 경로 테스트에서 "unused stubbing" 경고 방지
+        lenient().doAnswer(inv -> {
+            ((java.util.function.Consumer<org.springframework.transaction.TransactionStatus>) inv.getArgument(0))
+                    .accept(null);
+            return null;
+        }).when(transactionTemplate).executeWithoutResult(any());
     }
 
     // ─── getItineraries ───────────────────────────────────────────────────────


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

 WebFlux + JPA 혼용 환경에서 다중 save() 호출 간 데이터 불일치를 방지하기 위해 `TransactionTemplate` 기반 트랜잭션 관리를 도입합니다. 

# 연관 이슈 및 Close 할 이슈 작성
- `@Transactional`은 WebFlux의 `subscribeOn(dbScheduler)`로 스레드가 전환되는 순간 ThreadLocal 트랜잭션 컨텍스트가 끊겨 적용되지 않는다.                                                                                                                                               
- `Mono.fromCallable()` 내부에서 직접 호출하면 dbScheduler 스레드 위에서 실행되므로 트랜잭션이 올바르게 동작한다.                                                                                                                                     
- 트랜잭션이 없으면 다중 save() 호출 중 하나가 실패했을 때 나머지는 이미 커밋되어 데이터 불일치가 발생할 수 있다.

close #22 


# Pull Request 체크리스트

### DatabaseConfig
  - [x] 🔥 `TransactionTemplate` Bean 추가

  ### ChatRoomServiceImpl
  - [x] 🔥 `TransactionTemplate` 필드 추가
  - [x] 🔥 `createChatRoom()` — `chatRoomRepository.save()` + `itineraryRepository.save()` 를 `transactionTemplate.execute()` 로 묶음

  ### ItineraryServiceImpl
  - [x] 🔥 `TransactionTemplate` 필드 추가
  - [x] 🔥 `patchItinerary()` — `itineraryLogRepository.save()` + `itineraryRepository.save()` 를 `transactionTemplate.executeWithoutResult()` 로 묶음
  - [x] 🔥 `patchDayPlans()` — `itineraryLogRepository.save()` + `itineraryRepository.save()` 를 `transactionTemplate.executeWithoutResult()` 로 묶음

  ### ChatRoomServiceImplTest
  - [x] 🔥 `@Mock TransactionTemplate` 추가
  - [x] 🔥 `@BeforeEach` — `transactionTemplate.execute()` lenient stub 추가

  ### ItineraryServiceImplTest
  - [x] 🔥 `@Mock TransactionTemplate` 추가
  - [x] 🔥  `@BeforeEach` — `transactionTemplate.executeWithoutResult()` lenient stub 추가

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현