### PR TITLE
[Feature/#24] 채팅방 생성 시 초기 AI 메시지 저장 및 생성 응답 타임스탬프 보정

### DIFF
--- a/docs/api/v1/reservations/GET_api_v1_reservations.md
+++ b/docs/api/v1/reservations/GET_api_v1_reservations.md
@@ -50,58 +50,87 @@
   {
     "reservations": [
       {
-        "reservationId": "c3a7db7a-3b93-4b50-a667-4ac922e2ff11",
-        "itineraryId": "be4d9d2d-1d84-4b1b-bf4d-1ac6b9cc7f22",
-        "type": "flight",
+        "reservationId": "7d1a1213-f8c8-473e-ae19-3f17cb2ae8e5",
+        "itineraryId": "db2ed15e-bdcb-4b08-8f61-9db4868751e5",
+        "type": "car_rental",
+        "status": "confirmed",
+        "bookedBy": "ai",
+        "bookingUrl": null,
+        "externalRefId": "HERTZ-20260501",
+        "detail": {
+          "pickup": {
+            "datetime": "2026-05-01T13:00:00",
+            "location": "NRT T1"
+          },
+          "company": "Hertz",
+          "dropoff": {
+            "datetime": "2026-05-03T11:00:00",
+            "location": "NRT T1"
+          },
+          "car_model": "Toyota Camry"
+        },
+        "totalPrice": 95000,
+        "currency": "KRW",
+        "reservedAt": "2026-05-04T11:42:01.574526Z",
+        "cancelledAt": null,
+        "createdAt": "2026-05-04T11:42:01.358771Z",
+        "updatedAt": "2026-05-04T11:42:01.719527Z"
+      },
+      {
+        "reservationId": "0d765dae-4edd-4f80-b472-fc0714b31fc2",
+        "itineraryId": "db2ed15e-bdcb-4b08-8f61-9db4868751e5",
+        "type": "accommodation",
         "status": "confirmed",
         "bookedBy": "user",
-        "bookingUrl": "https://booking.example.com/flight/123",
-        "externalRefId": "KE12345678",
+        "bookingUrl": null,
+        "externalRefId": "LOTTE-20260501",
         "detail": {
-          "airline": "Korean Air",
-          "flight_no": "KE721",
+          "guests": 2,
+          "check_in": "2026-05-01",
+          "check_out": "2026-05-03",
+          "room_type": "디럭스 더블",
+          "hotel_name": "롯데호텔 도쿄"
+        },
+        "totalPrice": 180000,
+        "currency": "KRW",
+        "reservedAt": "2026-05-04T11:42:01.574526Z",
+        "cancelledAt": null,
+        "createdAt": "2026-05-04T11:42:01.358771Z",
+        "updatedAt": "2026-05-04T11:42:01.695785Z"
+      },
+      {
+        "reservationId": "7c87a366-c9f6-40b6-aa55-64f878f3df1a",
+        "itineraryId": "db2ed15e-bdcb-4b08-8f61-9db4868751e5",
+        "type": "flight",
+        "status": "confirmed",
+        "bookedBy": "ai",
+        "bookingUrl": null,
+        "externalRefId": "KE-20260501-001",
+        "detail": {
+          "airline": "대한항공",
+          "arrival": {
+            "airport": "NRT",
+            "datetime": "2026-05-01T11:30:00"
+          },
           "departure": {
             "airport": "ICN",
             "datetime": "2026-05-01T09:00:00"
           },
-          "arrival": {
-            "airport": "NRT",
-            "datetime": "2026-05-01T11:30:00"
-          }
+          "flight_no": "KE123",
+          "passengers": [
+            {
+              "name": "홍길동",
+              "passport": "M12345678"
+            }
+          ],
+          "seat_class": "economy"
         },
-        "totalPrice": 320000.00,
+        "totalPrice": 350000,
         "currency": "KRW",
-        "reservedAt": "2026-04-03T21:30:00Z",
+        "reservedAt": "2026-05-04T11:42:01.574526Z",
         "cancelledAt": null,
-        "createdAt": "2026-04-03T21:20:00Z",
-        "updatedAt": "2026-04-03T21:30:00Z"
-      },
-      {
-        "reservationId": "7f2f7e4f-5d29-47f7-8561-8ff22f0b2fd8",
-        "itineraryId": "3db203a5-d4fa-41b8-b30f-1d4cf58ce0e6",
-        "type": "flight",
-        "status": "confirmed",
-        "bookedBy": "ai",
-        "bookingUrl": "https://booking.example.com/flight/456",
-        "externalRefId": "OZ98765432",
-        "detail": {
-          "airline": "Asiana",
-          "flight_no": "OZ108",
-          "departure": {
-            "airport": "FCO",
-            "datetime": "2026-06-10T12:20:00"
-          },
-          "arrival": {
-            "airport": "ICN",
-            "datetime": "2026-06-11T06:20:00"
-          }
-        },
-        "totalPrice": 890000.00,
-        "currency": "KRW",
-        "reservedAt": "2026-04-05T10:10:00Z",
-        "cancelledAt": null,
-        "createdAt": "2026-04-05T10:00:00Z",
-        "updatedAt": "2026-04-05T10:10:00Z"
+        "createdAt": "2026-05-04T11:42:01.358771Z",
+        "updatedAt": "2026-05-04T11:42:01.635789Z"
       }
     ]
   }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -31,181 +31,181 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService {
 
-    private final UserRepository userRepository;
-    private final ChatRoomRepository chatRoomRepository;
-    private final ItineraryRepository itineraryRepository;
-    private final ReservationRepository reservationRepository;
-    private final Scheduler dbScheduler;
-    private final ObjectMapper objectMapper;
-    private final TransactionTemplate transactionTemplate;
+        private final UserRepository userRepository;
+        private final ChatRoomRepository chatRoomRepository;
+        private final ItineraryRepository itineraryRepository;
+        private final ReservationRepository reservationRepository;
+        private final Scheduler dbScheduler;
+        private final ObjectMapper objectMapper;
+        private final TransactionTemplate transactionTemplate;
 
-    @Override
-    public Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request) {
-        return Mono.fromCallable(() -> {
-            if (!userRepository.existsById(clerkId)) {
+        @Override
+        public Mono<CreateChatRoomResponse> createChatRoom(String clerkId, CreateChatRoomRequest request) {
+                return Mono.fromCallable(() -> {
+                        if (!userRepository.existsById(clerkId)) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found. Please sign up first.");
-            }
+                        }
 
-            if (request.startDate().isAfter(request.endDate())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                        "startDate must not be later than endDate.");
-            }
+                        if (request.startDate().isAfter(request.endDate())) {
+                                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                                "startDate must not be later than endDate.");
+                        }
 
-            if (request.childAges().size() != request.childCount()) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                        "childAges length must match childCount.");
-            }
+                        if (request.childAges().size() != request.childCount()) {
+                                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                                "childAges length must match childCount.");
+                        }
 
-            long totalDays = ChronoUnit.DAYS.between(request.startDate(), request.endDate()) + 1;
-            String name = (totalDays - 1) + "박 " + totalDays + "일 " + request.destination() + " 여행";
+                        long totalDays = ChronoUnit.DAYS.between(request.startDate(), request.endDate()) + 1;
+                        String name = (totalDays - 1) + "박 " + totalDays + "일 " + request.destination() + " 여행";
 
-            return transactionTemplate.execute(status -> {
-                ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.of(clerkId, name));
-                Itinerary itinerary = itineraryRepository.save(
-                        Itinerary.of(
-                                chatRoom.getId(),
-                                request.destination(),
-                                request.startDate(),
-                                request.endDate(),
-                                request.budget(),
-                                request.adultCount(),
-                                request.childCount(),
-                                request.childAges()
-                        )
-                );
-                return new CreateChatRoomResponse(
-                        chatRoom.getId(),
-                        chatRoom.getName(),
-                        itinerary.getId(),
-                        chatRoom.getClerkId(),
-                        chatRoom.getCreatedAt(),
+                        return transactionTemplate.execute(status -> {
+                                ChatRoom chatRoom = chatRoomRepository.saveAndFlush(ChatRoom.of(clerkId, name));
+                                Itinerary itinerary = itineraryRepository.save(
+                                        Itinerary.of(
+                                                chatRoom.getId(),
+                                                request.destination(),
+                                                request.startDate(),
+                                                request.endDate(),
+                                                request.budget(),
+                                                request.adultCount(),
+                                                request.childCount(),
+                                                request.childAges()
+                                        )
+                                );
+                                return new CreateChatRoomResponse(
+                                                chatRoom.getId(),
+                                                chatRoom.getName(),
+                                                itinerary.getId(),
+                                                chatRoom.getClerkId(),
+                                                chatRoom.getCreatedAt(),
                         chatRoom.getUpdatedAt()
                 );
-            });
-        }).subscribeOn(dbScheduler)
-                .onErrorMap(
-                        e -> !(e instanceof ResponseStatusException),
+                        });
+                }).subscribeOn(dbScheduler)
+                                .onErrorMap(
+                                                e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create chat room.")
                 );
-    }
+        }
 
-    @Override
-    public Mono<GetChatRoomsResponse> getChatRooms(String clerkId) {
-        return Mono.fromCallable(() -> {
-            if (!userRepository.existsById(clerkId)) {
+        @Override
+        public Mono<GetChatRoomsResponse> getChatRooms(String clerkId) {
+                return Mono.fromCallable(() -> {
+                        if (!userRepository.existsById(clerkId)) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found. Please sign up first.");
-            }
+                        }
 
-            List<GetChatRoomsResponse.ChatRoomItem> items = chatRoomRepository
-                    .findByClerkIdOrderByUpdatedAtDesc(clerkId)
-                    .stream()
-                    .map(room -> new GetChatRoomsResponse.ChatRoomItem(
-                            room.getId(),
-                            room.getName(),
-                            room.getClerkId(),
-                            room.getAiSummary(),
-                            parsePreferences(room.getPreferences()),
-                            room.getCreatedAt(),
+                        List<GetChatRoomsResponse.ChatRoomItem> items = chatRoomRepository
+                                        .findByClerkIdOrderByUpdatedAtDesc(clerkId)
+                                        .stream()
+                                        .map(room -> new GetChatRoomsResponse.ChatRoomItem(
+                                                        room.getId(),
+                                                        room.getName(),
+                                                        room.getClerkId(),
+                                                        room.getAiSummary(),
+                                                        parsePreferences(room.getPreferences()),
+                                                        room.getCreatedAt(),
                             room.getUpdatedAt()
                     ))
-                    .toList();
+                                        .toList();
 
-            return new GetChatRoomsResponse(items);
-        }).subscribeOn(dbScheduler)
-                .onErrorMap(
-                        e -> !(e instanceof ResponseStatusException),
+                        return new GetChatRoomsResponse(items);
+                }).subscribeOn(dbScheduler)
+                                .onErrorMap(
+                                                e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch chat rooms.")
                 );
-    }
+        }
 
-    @Override
-    public Mono<GetChatRoomResponse> getChatRoom(String clerkId, UUID roomId) {
-        return Mono.fromCallable(() -> {
-            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        @Override
+        public Mono<GetChatRoomResponse> getChatRoom(String clerkId, UUID roomId) {
+                return Mono.fromCallable(() -> {
+                        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Chat room not found."));
 
-            if (!chatRoom.getClerkId().equals(clerkId)) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                        "You do not have permission to access this chat room.");
-            }
+                        if (!chatRoom.getClerkId().equals(clerkId)) {
+                                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                                "You do not have permission to access this chat room.");
+                        }
 
-            UUID itineraryId = itineraryRepository.findByRoomId(roomId)
-                    .map(Itinerary::getId)
-                    .orElse(null);
+                        UUID itineraryId = itineraryRepository.findByRoomId(roomId)
+                                        .map(Itinerary::getId)
+                                        .orElse(null);
 
-            return new GetChatRoomResponse(
-                    chatRoom.getId(),
-                    chatRoom.getName(),
-                    chatRoom.getClerkId(),
-                    chatRoom.getAiSummary(),
-                    parsePreferences(chatRoom.getPreferences()),
-                    itineraryId,
-                    chatRoom.getCreatedAt(),
+                        return new GetChatRoomResponse(
+                                        chatRoom.getId(),
+                                        chatRoom.getName(),
+                                        chatRoom.getClerkId(),
+                                        chatRoom.getAiSummary(),
+                                        parsePreferences(chatRoom.getPreferences()),
+                                        itineraryId,
+                                        chatRoom.getCreatedAt(),
                     chatRoom.getUpdatedAt()
             );
-        }).subscribeOn(dbScheduler)
-                .onErrorMap(
-                        e -> !(e instanceof ResponseStatusException),
+                }).subscribeOn(dbScheduler)
+                                .onErrorMap(
+                                                e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to fetch chat room.")
                 );
-    }
+        }
 
-    @Override
-    public Mono<DeleteChatRoomResponse> deleteChatRoom(String clerkId, UUID roomId) {
-        return Mono.fromCallable(() -> {
-            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        @Override
+        public Mono<DeleteChatRoomResponse> deleteChatRoom(String clerkId, UUID roomId) {
+                return Mono.fromCallable(() -> {
+                        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Chat room not found."));
 
-            if (!chatRoom.getClerkId().equals(clerkId)) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                        "You do not have permission to delete this chat room.");
-            }
+                        if (!chatRoom.getClerkId().equals(clerkId)) {
+                                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                                "You do not have permission to delete this chat room.");
+                        }
 
-            itineraryRepository.findByRoomId(roomId).ifPresent(itinerary -> {
-                if (reservationRepository.existsByItineraryId(itinerary.getId())) {
-                    throw new ResponseStatusException(HttpStatus.CONFLICT,
-                            "Cannot delete chat room with existing reservations.");
-                }
-            });
+                        itineraryRepository.findByRoomId(roomId).ifPresent(itinerary -> {
+                                if (reservationRepository.existsByItineraryId(itinerary.getId())) {
+                                        throw new ResponseStatusException(HttpStatus.CONFLICT,
+                                                        "Cannot delete chat room with existing reservations.");
+                                }
+                        });
 
-            chatRoomRepository.deleteById(roomId);
+                        chatRoomRepository.deleteById(roomId);
 
-            return new DeleteChatRoomResponse(roomId, true);
-        }).subscribeOn(dbScheduler)
-                .onErrorMap(
-                        e -> !(e instanceof ResponseStatusException),
+                        return new DeleteChatRoomResponse(roomId, true);
+                }).subscribeOn(dbScheduler)
+                                .onErrorMap(
+                                                e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete chat room.")
                 );
-    }
+        }
 
-    @Override
-    public Mono<UpdateChatRoomNameResponse> updateChatRoomName(String clerkId, UUID roomId, String name) {
-        return Mono.fromCallable(() -> {
-            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        @Override
+        public Mono<UpdateChatRoomNameResponse> updateChatRoomName(String clerkId, UUID roomId, String name) {
+                return Mono.fromCallable(() -> {
+                        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Chat room not found."));
 
-            if (!chatRoom.getClerkId().equals(clerkId)) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                        "You do not have permission to update this chat room.");
-            }
+                        if (!chatRoom.getClerkId().equals(clerkId)) {
+                                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                                "You do not have permission to update this chat room.");
+                        }
 
-            chatRoom.updateName(name);
-            ChatRoom saved = chatRoomRepository.save(chatRoom);
+                        chatRoom.updateName(name);
+                        ChatRoom saved = chatRoomRepository.save(chatRoom);
 
-            return new UpdateChatRoomNameResponse(saved.getId(), saved.getName(), saved.getUpdatedAt());
-        }).subscribeOn(dbScheduler)
-                .onErrorMap(
-                        e -> !(e instanceof ResponseStatusException),
+                        return new UpdateChatRoomNameResponse(saved.getId(), saved.getName(), saved.getUpdatedAt());
+                }).subscribeOn(dbScheduler)
+                                .onErrorMap(
+                                                e -> !(e instanceof ResponseStatusException),
                         e -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to update chat room name.")
                 );
-    }
-
-    private Map<String, Object> parsePreferences(String preferences) {
-        if (preferences == null) return null;
-        try {
-            return objectMapper.readValue(preferences, new TypeReference<>() {});
-        } catch (Exception e) {
-            return null;
         }
-    }
+
+        private Map<String, Object> parsePreferences(String preferences) {
+        if (preferences == null) return null;
+                try {
+            return objectMapper.readValue(preferences, new TypeReference<>() {});
+                } catch (Exception e) {
+                        return null;
+                }
+        }
 }

--- a/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -8,6 +8,8 @@ import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
 import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
+import com.mju.capstone_backend.domain.chatmessage.entity.ChatMessage;
+import com.mju.capstone_backend.domain.chatmessage.repository.ChatMessageRepository;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
 import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
@@ -31,8 +33,11 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService {
 
+        private static final String INITIAL_AI_MESSAGE = "입력하신 정보를 확인했어요. 여행 계획에 더 참고해야 할 만한 사항이 있나요? 없다면 바로 일정을 생성할게요!";
+
         private final UserRepository userRepository;
         private final ChatRoomRepository chatRoomRepository;
+        private final ChatMessageRepository chatMessageRepository;
         private final ItineraryRepository itineraryRepository;
         private final ReservationRepository reservationRepository;
         private final Scheduler dbScheduler;
@@ -72,7 +77,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                                                 request.childCount(),
                                                 request.childAges()
                                         )
-                                );
+                                        );
+                                chatMessageRepository.save(
+                                                ChatMessage.of(chatRoom.getId(), "assistant", INITIAL_AI_MESSAGE));
                                 return new CreateChatRoomResponse(
                                                 chatRoom.getId(),
                                                 chatRoom.getName(),

--- a/src/test/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/chatroom/service/ChatRoomServiceImplTest.java
@@ -2,11 +2,8 @@ package com.mju.capstone_backend.domain.chatroom.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomRequest;
-import com.mju.capstone_backend.domain.chatroom.dto.CreateChatRoomResponse;
-import com.mju.capstone_backend.domain.chatroom.dto.DeleteChatRoomResponse;
-import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomResponse;
-import com.mju.capstone_backend.domain.chatroom.dto.GetChatRoomsResponse;
-import com.mju.capstone_backend.domain.chatroom.dto.UpdateChatRoomNameResponse;
+import com.mju.capstone_backend.domain.chatmessage.entity.ChatMessage;
+import com.mju.capstone_backend.domain.chatmessage.repository.ChatMessageRepository;
 import com.mju.capstone_backend.domain.chatroom.entity.ChatRoom;
 import com.mju.capstone_backend.domain.chatroom.repository.ChatRoomRepository;
 import com.mju.capstone_backend.domain.itinerary.entity.Itinerary;
@@ -47,6 +44,9 @@ class ChatRoomServiceImplTest {
 
     @Mock
     private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
 
     @Mock
     private ItineraryRepository itineraryRepository;
@@ -95,8 +95,9 @@ class ChatRoomServiceImplTest {
         Itinerary itinerary = mockItinerary(ITINERARY_ID, ROOM_ID);
 
         when(userRepository.existsById(CLERK_ID)).thenReturn(true);
-        when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(chatRoom);
+        when(chatRoomRepository.saveAndFlush(any(ChatRoom.class))).thenReturn(chatRoom);
         when(itineraryRepository.save(any(Itinerary.class))).thenReturn(itinerary);
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenAnswer(inv -> inv.getArgument(0));
 
         StepVerifier.create(chatRoomService.createChatRoom(CLERK_ID, request))
                 .assertNext(res -> {
@@ -105,8 +106,9 @@ class ChatRoomServiceImplTest {
                 })
                 .verifyComplete();
 
-        verify(chatRoomRepository).save(any(ChatRoom.class));
+        verify(chatRoomRepository).saveAndFlush(any(ChatRoom.class));
         verify(itineraryRepository).save(any(Itinerary.class));
+        verify(chatMessageRepository).save(any(ChatMessage.class));
     }
 
     @Test
@@ -125,6 +127,8 @@ class ChatRoomServiceImplTest {
                 .verify();
 
         verify(chatRoomRepository, never()).save(any());
+        verify(chatRoomRepository, never()).saveAndFlush(any());
+        verify(chatMessageRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
`transactionTemplate `안에서 `ChatRoom`을 저장한 직후 응답을 생성하는 구조라 `createdAt`, `updatedAt`가 flush되기 전에 읽혀 `null`로 내려올 수 있어 `saveAndFlush()`를 적용했습니다.
또한, 채팅방 생성 시 초기 안내용 AI 메시지를 서비스 단에서 함께 저장하도록 변경했습니다.

추가로 `docs/api/v1/reservations/GET_api_v1_reservations.md` 문서의 `response` 예시를 프론트 연동이 더 쉽도록 항공 단일 예시에서 항공, 숙소, 렌트카 예시로 확장했습니다.

# 연관 이슈 및 Close 할 이슈 작성
close #24

# Pull Request 체크리스트

- [x] 🔥 채팅방 생성 시 `saveAndFlush() `적용하여 `createdAt`, `updatedAt `응답 보정
- [x] 🔥 채팅방 생성 시 `ChatMessage`에 초기 AI 메시지 저장
- [x] 🔥 채팅방 생성 로직 변경에 따른 `ChatRoomServiceImplTest` 업데이트
- [x] 🔥 `GET /api/v1/reservations` 문서의 `response` 예시를 항공, 숙소, 렌트카로 수정

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?