### PR TITLE
test(#34) : sendMessage 에러 반환 형식(SSE)에 맞춰, SSE 이벤트 검증 로직 교체

### DIFF
--- a/src/test/java/com/mju/capstone_backend/domain/chatmessage/service/ChatMessageServiceImplTest.java
+++ b/src/test/java/com/mju/capstone_backend/domain/chatmessage/service/ChatMessageServiceImplTest.java
@@ -360,9 +360,12 @@ class ChatMessageServiceImplTest {
 
         // when & then
         StepVerifier.create(chatMessageService.sendMessage(CLERK_ID, ROOM_ID, "항공권 예약해줘"))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == NOT_FOUND)
-                .verify();
+                .assertNext(sse -> {
+                    assertThat(sse.event()).isEqualTo("error");
+                    assertThat(sse.data()).isInstanceOf(Map.class);
+                    assertThat(((Map<?, ?>) sse.data()).get("status")).isEqualTo(404);
+                })
+                .verifyComplete();
     }
 
     @Test
@@ -430,9 +433,12 @@ class ChatMessageServiceImplTest {
 
         // when & then
         StepVerifier.create(chatMessageService.sendMessage(CLERK_ID, ROOM_ID, "예약 취소해줘"))
-                .expectErrorMatches(e -> e instanceof ResponseStatusException rse
-                        && rse.getStatusCode() == NOT_FOUND)
-                .verify();
+                .assertNext(sse -> {
+                    assertThat(sse.event()).isEqualTo("error");
+                    assertThat(sse.data()).isInstanceOf(Map.class);
+                    assertThat(((Map<?, ?>) sse.data()).get("status")).isEqualTo(404);
+                })
+                .verifyComplete();
     }
 
     // ─── 헬퍼 ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

# 연관 이슈 및 Close 할 이슈 작성
sendMessage 에러 반환 형식(SSE)에 맞춰, SSE 이벤트 검증 로직 교체

close #34

# Pull Request 체크리스트
- [x] 🔥sendMessage 에러 반환 형식(SSE)에 맞춰, SSE 이벤트 검증 로직 교체

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현